### PR TITLE
Bug fixes and an extension of UniformSO3

### DIFF
--- a/examples/bop_object_physics_positioning/README.md
+++ b/examples/bop_object_physics_positioning/README.md
@@ -6,7 +6,7 @@ This example serves as the basis for generating the synthetic data provided at t
 
 ## Usage
 
-Execute in the Blender-Pipeline main directory:
+Execute in the BlenderProc main directory:
 
 ```
 python scripts/download_cc_textures.py 

--- a/examples/bop_object_physics_positioning/config.yaml
+++ b/examples/bop_object_physics_positioning/config.yaml
@@ -50,7 +50,6 @@
       "module": "loader.BopLoader",
       "config": {
         "bop_dataset_path": "<args:0>/lm",
-        "split": "val",
         "mm2m": True,
         "model_type": "",
         "sample_objects": True,
@@ -308,7 +307,7 @@
     {
       "module": "renderer.RgbRenderer",
       "config": {
-        "samples": 150
+        "samples": 50
       }
     },
     {

--- a/src/lighting/LightModule.py
+++ b/src/lighting/LightModule.py
@@ -50,5 +50,5 @@ class LightModule(Module):
         light_obj.location = config.get_list("location", [0, 0, 0])
         light_obj.rotation_euler = config.get_list("rotation", [0, 0, 0])
         light_data.energy = config.get_float("energy", 10.)
-        light_data.color = config.get_list("color", [1, 1, 1])
+        light_data.color = config.get_list("color", [1, 1, 1])[:3]
         light_data.distance = config.get_float("distance", 0)

--- a/src/loader/BopLoader.py
+++ b/src/loader/BopLoader.py
@@ -305,7 +305,7 @@ class BopLoader(Loader):
         if not self._is_ycbv:
             mat = self._load_materials(cur_obj)
             self._link_col_node(mat)
-        else:
+        elif texture_file_path != "":
             # ycbv objects contain normal image textures, which should be used instead of the vertex colors
             self._load_texture(cur_obj, texture_file_path)
         cur_obj["is_bop_object"] = True

--- a/src/provider/sampler/Shell.py
+++ b/src/provider/sampler/Shell.py
@@ -5,7 +5,7 @@ from src.main.Provider import Provider
 
 
 class Shell(Provider):
-    """ Samples a point from the space in between two spheres with a a double spherical angle with apex in the center
+    """ Samples a point from the space in between two spheres with a double spherical angle with apex in the center
         of those two spheres.
 
         Example 1: Sample a point from a space in between two structure-defining spheres defined by min and max radii,

--- a/src/provider/sampler/UniformSO3.py
+++ b/src/provider/sampler/UniformSO3.py
@@ -1,11 +1,22 @@
 import mathutils
+import random
 import numpy as np
 
 from src.main.Provider import Provider
 
 
 class UniformSO3(Provider):
-    """ Uniformly samples rotations from SO(3). """
+    """ Uniformly samples rotations from SO(3).
+
+    **Configuration**:
+
+    .. csv-table::
+        :header: "Parameter", "Description"
+
+        "around_x", "Whether to rotate around X-axis. Type: bool. Default: True."
+        "around_y", "Whether to rotate around Y-axis. Type: bool. Default: True."
+        "around_z", "Whether to rotate around Z-axis. Type: bool. Default: True."
+    """
 
     def __init__(self, config):
         Provider.__init__(self, config)
@@ -14,8 +25,28 @@ class UniformSO3(Provider):
         """
         :return: Sampled rotation in euler angles. Type: Mathutils Vector
         """
-        quat_rand = self._random_quaternion()
-        euler_rand = mathutils.Quaternion(quat_rand).to_euler()
+        # Indicators of which axes to rotate around.
+        around_x = self.config.get_bool('around_x', True)
+        around_y = self.config.get_bool('around_y', True)
+        around_z = self.config.get_bool('around_z', True)
+
+        # Uniform sampling in full SO3.
+        if around_x and around_y and around_z:
+            quat_rand = self._random_quaternion()
+            euler_rand = mathutils.Quaternion(quat_rand).to_euler()
+
+        # Uniform sampling of angles around the selected axes.
+        else:
+            def random_angle():
+                return random.uniform(0, 2 * np.pi)
+            mat_rand = mathutils.Matrix.Identity(3)
+            if around_x:
+                mat_rand @= mathutils.Matrix.Rotation(random_angle(), 3, 'X')
+            if around_y:
+                mat_rand @= mathutils.Matrix.Rotation(random_angle(), 3, 'Y')
+            if around_z:
+                mat_rand @= mathutils.Matrix.Rotation(random_angle(), 3, 'Z')
+            euler_rand = mat_rand.to_euler()
 
         return mathutils.Vector(euler_rand)
 


### PR DESCRIPTION
The extension of UniformSO3 allows selecting which axes to rotate around. This is useful, e.g., for the generation of initial object poses in bop_object_physics_positioning. In datasets such as LineMod, the objects are always standing up-right in the test images. Hence, we want to randomize the orientation of the objects only around the Z-axis (i.e. the up-right axis).