### PR TITLE
A new version of the BOP writer

### DIFF
--- a/examples/bop_object_physics_positioning/config.yaml
+++ b/examples/bop_object_physics_positioning/config.yaml
@@ -278,8 +278,8 @@
           "location": {
             "provider": "sampler.Shell",
             "center": [0, 0, 0],
-            "radius_min": 0.7,
-            "radius_max": 1.3,
+            "radius_min": 0.4,
+            "radius_max": 1.5,
             "elevation_min": 10,
             "elevation_max": 89.9
           },
@@ -307,7 +307,8 @@
     {
       "module": "renderer.RgbRenderer",
       "config": {
-        "samples": 50
+        "samples": 50,
+        "render_depth": True
       }
     },
     {
@@ -323,7 +324,11 @@
       "module": "writer.Hdf5Writer"
     },
     {
-      "module": "writer.BopWriter"
+      "module": "writer.BopWriter",
+      "config": {
+        "dataset": "lm",
+        "append_to_existing_output": True
+      }
     }
   ]
 }

--- a/src/writer/BopWriter.py
+++ b/src/writer/BopWriter.py
@@ -342,11 +342,15 @@ class BopWriter(StateWriter):
 
             # Copy the resulting RGB image.
             rgb_output = self._find_registered_output_by_key("colors")
+            if rgb_output is None:
+                raise Exception("RGB image has not been rendered.")
             rgb_fpath = self.rgb_tpath.format(chunk_id=chunk_id, im_id=current_frame_id)
             shutil.copyfile(rgb_output['path'] % frame_id, rgb_fpath)
 
             # Load the resulting depth image.
             depth_output = self._find_registered_output_by_key("depth")
+            if depth_output is None:
+                raise Exception("Depth image has not been rendered.")
             depth = load_image(depth_output['path'] % frame_id, num_channels=1)
             depth = depth.squeeze(axis=2)
 

--- a/src/writer/BopWriter.py
+++ b/src/writer/BopWriter.py
@@ -1,17 +1,95 @@
 import json
 import os
 import math
+import glob
+import numpy as np
+import png
+import shutil
 
 import bpy
 from mathutils import Euler, Matrix, Vector
 
 from src.utility.BlenderUtility import get_all_mesh_objects
+from src.utility.BlenderUtility import load_image
 from src.writer.StateWriter import StateWriter
 
 
+def load_json(path, keys_to_int=False):
+    """Loads content of a JSON file.
+    From the BOP toolkit (https://github.com/thodan/bop_toolkit).
+
+    :param path: Path to the JSON file.
+    :return: Content of the loaded JSON file.
+    """
+    # Keys to integers.
+    def convert_keys_to_int(x):
+        return {int(k) if k.lstrip('-').isdigit() else k: v for k, v in x.items()}
+
+    with open(path, 'r') as f:
+        if keys_to_int:
+            content = json.load(f, object_hook=lambda x: convert_keys_to_int(x))
+        else:
+            content = json.load(f)
+
+    return content
+
+
+def save_json(path, content):
+    """ Saves the content to a JSON file in a human-friendly format.
+    From the BOP toolkit (https://github.com/thodan/bop_toolkit).
+
+    :param path: Path to the output JSON file.
+    :param content: Dictionary/list to save.
+    """
+    with open(path, 'w') as f:
+
+        if isinstance(content, dict):
+            f.write('{\n')
+            content_sorted = sorted(content.items(), key=lambda x: x[0])
+            for elem_id, (k, v) in enumerate(content_sorted):
+                f.write(
+                    '  \"{}\": {}'.format(k, json.dumps(v, sort_keys=True)))
+                if elem_id != len(content) - 1:
+                    f.write(',')
+                f.write('\n')
+            f.write('}')
+
+        elif isinstance(content, list):
+            f.write('[\n')
+            for elem_id, elem in enumerate(content):
+                f.write('  {}'.format(json.dumps(elem, sort_keys=True)))
+                if elem_id != len(content) - 1:
+                    f.write(',')
+                f.write('\n')
+            f.write(']')
+
+        else:
+            json.dump(content, f, sort_keys=True)
+
+
+def save_depth(path, im):
+    """Saves a depth image (16-bit) to a PNG file.
+    From the BOP toolkit (https://github.com/thodan/bop_toolkit).
+
+    :param path: Path to the output depth image file.
+    :param im: ndarray with the depth image to save.
+    """
+    if path.split('.')[-1].lower() != 'png':
+        raise ValueError('Only PNG format is currently supported.')
+
+    im[im > 65535] = 65535
+    im_uint16 = np.round(im).astype(np.uint16)
+
+    # PyPNG library can save 16-bit PNG and is faster than imageio.imwrite().
+    w_depth = png.Writer(im.shape[1], im.shape[0], greyscale=True, bitdepth=16)
+    with open(path, 'wb') as f:
+        w_depth.write(f, np.reshape(im_uint16, (-1, im.shape[1])))
+
+
 class BopWriter(StateWriter):
-    """ Writes objects and camera details for each frame according to the bop datasets format.
-        For more details about the bop datasets visit the bop toolkit docs
+    """ Saves the synthesized dataset in the BOP format. The dataset is split
+        into chunks which are saved as individual "scenes". For more details
+        about the BOP format, visit the BOP toolkit docs:
         https://github.com/thodan/bop_toolkit/blob/master/docs/bop_datasets_format.md
 
     **Attributes per object**:
@@ -19,67 +97,84 @@ class BopWriter(StateWriter):
     .. csv-table::
        :header: "Keyword", "Description"
 
-       "append_to_existing_output", "If true and if there is already a scene_gt.json and scene_camera.json files in "
-                                    "the output directory, the new frames will be appended to the existing files. "
+       "dataset", "Annotations for objects of this dataset will be saved. Type: string."
+       "append_to_existing_output", "If true, the new frames will be appended to the existing ones. "
                                     "Type: bool. Default: False"
     """
 
     def __init__(self, config):
         StateWriter.__init__(self, config)
 
+        # Parse configuration.
+        self.dataset = self.config.get_string("dataset", "")
+        if self.dataset == "":
+            raise Exception("Dataset not specified.")
+        self.append_to_existing_output =\
+            self.config.get_bool("append_to_existing_output", False)
 
-    def initialize_bop_groups(self):
-        """ Get and group all objects to their respective bop dataset
-        """
+        # Number of frames saved in each "scene directory".
+        self.frames_per_scene_dir = 1000
 
-        all_mesh_objects = get_all_mesh_objects()
-        bop_datasets = {}
-        for obj in all_mesh_objects:
-            if "bop_dataset_name" in obj:
-                if obj["bop_dataset_name"] in bop_datasets:
-                    bop_datasets[obj["bop_dataset_name"]].append(obj)
-                else:
-                    bop_datasets[obj["bop_dataset_name"]] = [obj]
-        self.bop_datasets = bop_datasets
+        # Format of the RGB and depth images.
+        rgb_ext = '.png'
+        depth_ext = '.png'
 
-        # For each group, make a seperate output directory
+        # Multiply the output depth image with this factor to get depth in mm.
+        self.depth_scale = 0.1
+
+        # Output paths.
         base_path = self._determine_output_dir(False)
-        self._bop_data_dir = os.path.join(base_path, 'bop_data')
-        # Create base directory if not exists
-        if not os.path.exists(self._bop_data_dir):
-            os.makedirs(self._bop_data_dir)
-        # Create subdirectorys if don't exist
-        self._bop_data_sub_dirs = {}
-        for group in self.bop_datasets:
-            self._bop_data_sub_dirs[group] = os.path.join(base_path, 'bop_data', group)
-            if not os.path.exists(self._bop_data_sub_dirs[group]):
-                os.makedirs(self._bop_data_sub_dirs[group])
+        self.dataset_dir = os.path.join(base_path, 'bop_data', self.dataset)
+        self.scenes_dir = os.path.join(self.dataset_dir, 'train_synt')
+        self.camera_path = os.path.join(self.dataset_dir, 'camera.json')
+        self.rgb_tpath = os.path.join(
+            self.scenes_dir, '{scene_id:06d}', 'rgb', '{im_id:06d}' + rgb_ext)
+        self.depth_tpath = os.path.join(
+            self.scenes_dir, '{scene_id:06d}', 'depth', '{im_id:06d}' + depth_ext)
+        self.scene_camera_tpath = os.path.join(
+            self.scenes_dir, '{scene_id:06d}', 'scene_camera.json')
+        self.scene_gt_tpath = os.path.join(
+            self.scenes_dir, '{scene_id:06d}', 'scene_gt.json')
 
-        # For each subdirectory create internal file paths
-        self._scene_gt_path = {}
-        self._scene_camera_path = {}
-        self._camera_path = {}
-        for group in self.bop_datasets:
-            self._scene_gt_path[group] = os.path.join(self._bop_data_sub_dirs[group], 'scene_gt.json') 
-            self._scene_camera_path[group] = os.path.join(self._bop_data_sub_dirs[group], 'scene_camera.json') 
-            self._camera_path[group] = os.path.join(self._bop_data_sub_dirs[group], 'camera.json')
-
+        # Create the output directory structure.
+        if not os.path.exists(self.dataset_dir):
+            os.makedirs(self.dataset_dir)
+            os.makedirs(self.scenes_dir)
+        elif not self.append_to_existing_output:
+            raise Exception("The output folder already exists: {}.".format(
+                self.dataset_dir))
 
     def run(self):
-        """ Collects the camera and camera object then for each file to be written excutes its function"""
-        # Initialize and group bop dataset objects
-        self.initialize_bop_groups()
+        """ Stores frames and annotations for objects from the specified dataset.
+        """
+        # Select objects from the specified dataset.
+        all_mesh_objects = get_all_mesh_objects()
+        self.dataset_objects = []
+        for obj in all_mesh_objects:
+            if "bop_dataset_name" in obj:
+                if obj["bop_dataset_name"] == self.dataset:
+                    self.dataset_objects.append(obj)
 
-        # Collect camera and camera object
+        # Paths to the already existing scene folders (such folders may exist
+        # when appending to an existing dataset).
+        scene_dirs = sorted(glob.glob(os.path.join(self.scenes_dir, '*')))
+        scene_dirs = [d for d in scene_dirs if os.path.isdir(d)]
+
+        # Get the ID of the last already existing frame.
+        self.frame_id_offset = 0
+        if len(scene_dirs):
+            last_scene_gt_fpath = os.path.join(sorted(scene_dirs)[-1], 'scene_gt.json')
+            scene_gt = load_json(last_scene_gt_fpath, keys_to_int=True)
+            self.frame_id_offset = int(sorted(scene_gt.keys())[-1]) + 1
+
+        # Get the camera.
         cam_ob = bpy.context.scene.camera
         self.cam = cam_ob.data
         self.cam_pose = (self.cam, cam_ob)
 
-        # for each bop dataset group
-        for group in self.bop_datasets:       
-            self._write_scene_gt(group)
-            self._write_scene_camera(group)
-            self._write_camera(group)
+        # Save the data.
+        self._write_camera()
+        self._write_frames()
 
     def _get_camera_attribute(self, cam_pose, attribute_name):
         """ Returns the value of the requested attribute for the given object.
@@ -120,14 +215,16 @@ class BopWriter(StateWriter):
         return super()._get_attribute(object, attribute_name)
 
     def get_camK_from_blender_attributes(self, cam_pose):
-        half_angle_x = self._get_camera_attribute(cam_pose, 'half_fov_x')
-        half_angle_y = self._get_camera_attribute(cam_pose, 'half_fov_y')
+        """ Constructs the camera matrix K.
+
+        :param cam_pose: Camera info.
+        :return: 3x3 camera matrix K.
+        """
         shift_x = self._get_camera_attribute(cam_pose, 'shift_x')
         shift_y = self._get_camera_attribute(cam_pose, 'shift_y')
         syn_cam_K = self._get_camera_attribute(cam_pose, 'loaded_intrinsics')
-
-
-        width, height = bpy.context.scene.render.resolution_x, bpy.context.scene.render.resolution_y
+        width = bpy.context.scene.render.resolution_x
+        height = bpy.context.scene.render.resolution_y
 
         cam_K = [0.] * 9
         cam_K[-1] = 1
@@ -142,91 +239,9 @@ class BopWriter(StateWriter):
 
         return cam_K
 
-    def _write_scene_gt(self, bop_group): 
-        """ Creates and writes scene_gt.json in output_dir.
-        
-        :param bop_group: BOP dataset for which to write the gt.
-        :return
+    def _write_camera(self):
+        """ Writes camera.json into dataset_dir.
         """
-        scene_gt = {} 
-        # Calculate image numbering offset, if append_to_existing_output is activated and scene ground truth exists
-        if self.config.get_bool("append_to_existing_output", False) and os.path.exists(self._scene_gt_path[bop_group]):
-            with open(self._scene_gt_path[bop_group], 'r') as fp:
-                scene_gt = json.load(fp)
-            frame_offset = int(sorted(scene_gt.keys())[-1]) + 1
-        else:
-            frame_offset = 0
-
-        # Go Through all frames
-        for frame in range(bpy.context.scene.frame_start, bpy.context.scene.frame_end):
-            bpy.context.scene.frame_set(frame)
-            current_frame = frame + frame_offset
-            scene_gt[current_frame] = []
-
-            camera_rotation = self._get_camera_attribute(self.cam_pose, 'rotation_euler')
-            camera_translation = self._get_camera_attribute(self.cam_pose, 'location')
-            H_c2w = Matrix.Translation(Vector(camera_translation)) @ Euler(camera_rotation, 'XYZ').to_matrix().to_4x4()
-
-            # blender to opencv coordinates
-            H_c2w_opencv = H_c2w @ Matrix.Rotation(math.radians(-180), 4, "X")
-
-            for idx, obj in enumerate(self.bop_datasets[bop_group]):
-                
-                object_rotation = self._get_object_attribute(obj, 'rotation_euler')
-                object_translation = self._get_object_attribute(obj, 'location')
-                H_m2w = Matrix.Translation(Vector(object_translation)) @ Euler(object_rotation, 'XYZ').to_matrix().to_4x4()
-                
-                cam_H_m2c = (H_m2w.inverted() @ H_c2w_opencv).inverted()
-
-                cam_R_m2c = cam_H_m2c.to_quaternion().to_matrix()
-                cam_R_m2c = list(cam_R_m2c[0]) + list(cam_R_m2c[1]) + list(cam_R_m2c[2])
-                cam_t_m2c = list(cam_H_m2c.to_translation() * 1000.)
-                
-                scene_gt[current_frame].append({'cam_R_m2c': cam_R_m2c,
-                                                'cam_t_m2c': cam_t_m2c,
-                                                'obj_id': self._get_object_attribute(obj, 'id')})
-
-            dir_folder = os.path.dirname(self._scene_gt_path[bop_group])
-            if not os.path.exists(dir_folder):
-                os.makedirs(dir_folder)
-
-            with open(self._scene_gt_path[bop_group], 'w') as scene_gt_file:
-                json.dump(scene_gt, scene_gt_file)
-        
-        return
-
-    def _write_scene_camera(self, bop_group):
-        """ Creates and writes scene_camera.json in output_dir.
-        
-        :param bop_group: BOP dataset for which to write the gt.
-        :return
-        """ 
-        scene_camera = {} 
-        # Calculate image numbering offset, if append_to_existing_output is activated and scene ground truth exists
-        if self.config.get_bool("append_to_existing_output", False) and os.path.exists(self._scene_camera_path[bop_group]):
-            with open(self._scene_camera_path[bop_group], 'r') as fp:
-                scene_camera = json.load(fp)
-            frame_offset = int(sorted(scene_camera.keys())[-1]) + 1
-        else:
-            frame_offset = 0 
-
-        # Go Through all frames
-        for frame in range(bpy.context.scene.frame_start, bpy.context.scene.frame_end):
-            bpy.context.scene.frame_set(frame)
-            current_frame = frame + frame_offset
-            scene_camera[current_frame] = {'cam_K': list(self.get_camK_from_blender_attributes(self.cam_pose)),
-                                   'depth_scale': 0.001}
-            with open(self._scene_camera_path[bop_group], 'w') as scene_camera_file:
-                json.dump(scene_camera, scene_camera_file)
-
-        return
-
-    def _write_camera(self, bop_group):
-        """ Creates and writes camera.json in output_dir.
-        
-        :param bop_group: BOP dataset for which to write the gt.
-        :return
-        """       
         if 'loaded_resolution' in self.cam:
             width, height = self.cam['loaded_resolution']
         else:
@@ -236,13 +251,122 @@ class BopWriter(StateWriter):
         cam_K = self.get_camK_from_blender_attributes(self.cam_pose)
         camera = {'cx': cam_K[2],
                   'cy': cam_K[5],
-                  'depth_scale': 0.001,
+                  'depth_scale': self.depth_scale,
                   'fx': cam_K[0],
                   'fy': cam_K[4],
                   'height': height,
                   'width': width}
 
-        with open(self._camera_path[bop_group], 'w') as camera_file:
-            json.dump(camera, camera_file)
+        save_json(self.camera_path, camera)
+
+        return
+
+    def _get_frame_gt(self):
+        """ Returns GT annotations for the active camera.
+
+        :return: A list of GT annotations.
+        """
+        camera_rotation = self._get_camera_attribute(self.cam_pose, 'rotation_euler')
+        camera_translation = self._get_camera_attribute(self.cam_pose, 'location')
+        H_c2w = Matrix.Translation(Vector(camera_translation)) @ Euler(
+            camera_rotation, 'XYZ').to_matrix().to_4x4()
+
+        # Blender to opencv coordinates.
+        H_c2w_opencv = H_c2w @ Matrix.Rotation(math.radians(-180), 4, "X")
+
+        frame_gt = []
+        for idx, obj in enumerate(self.dataset_objects):
+            object_rotation = self._get_object_attribute(obj, 'rotation_euler')
+            object_translation = self._get_object_attribute(obj, 'location')
+            H_m2w = Matrix.Translation(Vector(object_translation)) @ Euler(
+                object_rotation, 'XYZ').to_matrix().to_4x4()
+
+            cam_H_m2c = (H_m2w.inverted() @ H_c2w_opencv).inverted()
+
+            cam_R_m2c = cam_H_m2c.to_quaternion().to_matrix()
+            cam_R_m2c = list(cam_R_m2c[0]) + list(cam_R_m2c[1]) + list(cam_R_m2c[2])
+            cam_t_m2c = list(cam_H_m2c.to_translation() * 1000.)
+
+            frame_gt.append({
+                'cam_R_m2c': cam_R_m2c,
+                'cam_t_m2c': cam_t_m2c,
+                'obj_id': self._get_object_attribute(obj, 'id')
+            })
+
+        return frame_gt
+
+    def _get_frame_camera(self):
+        """ Returns camera parameters for the active camera.
+        """
+        return {
+            'cam_K': list(self.get_camK_from_blender_attributes(self.cam_pose)),
+            'depth_scale': self.depth_scale
+        }
+
+    def _write_frames(self):
+        """ Writes images, scene GT and scene camera info.
+        """
+        # Initialize structures for the GT annotations and camera info.
+        if self.frame_id_offset % self.frames_per_scene_dir == 0:
+            scene_gt = {}
+            scene_camera = {}
+        else:
+            # Load GT and camera info of the scene we are appending to.
+            scene_id = int(self.frame_id_offset / self.frames_per_scene_dir)
+            scene_gt = load_json(self.scene_gt_tpath.format(scene_id=scene_id), keys_to_int=True)
+            scene_camera = load_json(self.scene_camera_tpath.format(scene_id=scene_id), keys_to_int=True)
+
+        # Go through all frames.
+        num_new_frames = bpy.context.scene.frame_end - bpy.context.scene.frame_start
+        for frame_id in range(bpy.context.scene.frame_start, bpy.context.scene.frame_end):
+            # Activate frame.
+            bpy.context.scene.frame_set(frame_id)
+
+            # Frame and scene ID's.
+            current_frame_id = frame_id + self.frame_id_offset
+            scene_id = int(current_frame_id / self.frames_per_scene_dir)
+
+            # Prepare folders for a new scene.
+            if current_frame_id % self.frames_per_scene_dir == 0:
+                os.makedirs(os.path.dirname(self.rgb_tpath.format(scene_id=scene_id, im_id=0)))
+                os.makedirs(os.path.dirname(self.depth_tpath.format(scene_id=scene_id, im_id=0)))
+
+            # Get GT annotations and camera info for the current frame.
+            scene_gt[current_frame_id] = self._get_frame_gt()
+            scene_camera[current_frame_id] = self._get_frame_camera()
+
+            # Copy the resulting RGB image.
+            rgb_output = self._find_registered_output_by_key("colors")
+            rgb_fpath = self.rgb_tpath.format(scene_id=scene_id, im_id=current_frame_id)
+            shutil.copyfile(rgb_output['path'] % frame_id, rgb_fpath)
+
+            # Load the resulting depth image.
+            depth_output = self._find_registered_output_by_key("depth")
+            depth = load_image(depth_output['path'] % frame_id, num_channels=1)
+            depth = depth.squeeze(axis=2)
+
+            # Scale the depth to retain a higher precision (the depth is saved
+            # as a 16-bit PNG image with range 0-65535).
+            depth_mm = 1000.0 * depth  # [m] -> [mm]
+            depth_mm_scaled = depth_mm / float(self.depth_scale)
+
+            # Save the scaled depth image.
+            depth_fpath = self.depth_tpath.format(scene_id=scene_id, im_id=current_frame_id)
+            save_depth(depth_fpath, depth_mm_scaled)
+
+            # Save the scene info if we are at the end of a scene/chunk or at
+            # the last new frame.
+            if ((current_frame_id + 1) % self.frames_per_scene_dir == 0) or\
+                  (frame_id == num_new_frames - 1):
+
+                # Save scene GT annotations.
+                save_json(self.scene_gt_tpath.format(scene_id=scene_id), scene_gt)
+
+                # Save scene camera info.
+                save_json(self.scene_camera_tpath.format(scene_id=scene_id), scene_camera)
+
+                # Reset structures for GT and camera info.
+                scene_gt = {}
+                scene_camera = {}
 
         return

--- a/src/writer/BopWriter.py
+++ b/src/writer/BopWriter.py
@@ -155,6 +155,11 @@ class BopWriter(StateWriter):
                 if obj["bop_dataset_name"] == self.dataset:
                     self.dataset_objects.append(obj)
 
+        # Check if there is any object from the specified dataset.
+        if not self.dataset_objects:
+            raise Exception("The scene does not contain any object from the "
+                            "specified dataset: {}".format(self.dataset))
+
         # Paths to the already existing scene folders (such folders may exist
         # when appending to an existing dataset).
         scene_dirs = sorted(glob.glob(os.path.join(self.scenes_dir, '*')))


### PR DESCRIPTION
The BOP writer now stores the full dataset (including images) in the BOP format.

The writer assumes that self._find_registered_output_by_key("depth") provides depth images (i.e. the Z coordinate is saved at each pixel). However, currently, this provides distance images (i.e. the distance from the optical center is saved at each pixel). I assume this is a bug that will be fixed in the next release.