### PR TITLE
Change ObjectStateWriter so the attribute name is written as well

### DIFF
--- a/src/writer/ObjectStateWriter.py
+++ b/src/writer/ObjectStateWriter.py
@@ -11,13 +11,13 @@ class ObjectStateWriter(StateWriter):
         self.object_writer = ItemWriter(self._get_attribute)
 
     def run(self):
-        """ Collect all mesh objects and writes their id and pose."""
+        """ Collect all mesh objects and writes their id, name and pose."""
         objects = []
         for object in get_all_mesh_objects():
             objects.append(object)
 
         self.write_attributes_to_file(self.object_writer, objects, "object_states_", "object_states",
-                                      ["id", "location", "rotation_euler"])
+                                      ["id", "name", "location", "rotation_euler"])
 
     def _get_attribute(self, object, attribute_name):
         """ Returns the value of the requested attribute for the given object.

--- a/src/writer/StateWriter.py
+++ b/src/writer/StateWriter.py
@@ -39,7 +39,6 @@ class StateWriter(Module):
         """
         file_prefix = self.config.get_string("output_file_prefix", default_file_prefix)
         path_prefix = os.path.join(self._determine_output_dir(), file_prefix)
-
         item_writer.write_items_to_file(path_prefix, items, self.config.get_list("attributes_to_write", default_attributes))
 
         self._register_output(file_prefix, self.config.get_string("output_key", default_output_key), ".npy", version)
@@ -57,6 +56,8 @@ class StateWriter(Module):
             if item.name not in self.name_to_id:
                 self.name_to_id[item.name] = len(self.name_to_id.values())
             return self.name_to_id[item.name]
+        elif attribute_name == "name":
+            return item.name
         elif attribute_name == "location":
             return Utility.transform_point_to_blender_coord_frame(item.location, self.destination_frame)
         elif attribute_name == "rotation_euler":

--- a/src/writer/StateWriter.py
+++ b/src/writer/StateWriter.py
@@ -39,6 +39,7 @@ class StateWriter(Module):
         """
         file_prefix = self.config.get_string("output_file_prefix", default_file_prefix)
         path_prefix = os.path.join(self._determine_output_dir(), file_prefix)
+        
         item_writer.write_items_to_file(path_prefix, items, self.config.get_list("attributes_to_write", default_attributes))
 
         self._register_output(file_prefix, self.config.get_string("output_key", default_output_key), ".npy", version)


### PR DESCRIPTION
**Background:**
When the ObjectStateWriter and the Hdf5Writer is in config.yaml the object id and object poses are written to the .hdf5 file. The id corresponds to the blender scene and there is no information which original 3D-object (e.g. obj_000001.ply or ape.ply) the given information belongs to. 

 **Enhancement:**
Add the attribute "name" to ObjectStateWriter, so that the name information of the original .ply-object is written to the file as well.
