### PR TITLE
solves: iss_37 delete unnecessary line

### DIFF
--- a/examples/bop_object_physics_positioning/config.yaml
+++ b/examples/bop_object_physics_positioning/config.yaml
@@ -168,7 +168,7 @@
           }
         },
         "cp_physics": False,
-        "cp_category_id": 333
+        
       }
     },
     {


### PR DESCRIPTION
As discussed in Issue #37，I think this [line](https://github.com/DLR-RM/BlenderProc/blob/2bc01e2224d8b11e81af730fbdf48e56f39be2e5/examples/bop_object_physics_positioning/config.yaml#L171) should be deleted so as not to confuse others