### PR TITLE
Iss 43 coco support different categories

### DIFF
--- a/examples/bop_object_pose_sampling/config.yaml
+++ b/examples/bop_object_pose_sampling/config.yaml
@@ -113,7 +113,8 @@
     {
       "module": "writer.CocoAnnotationsWriter",
       "config": {
-        "supercategory": "<args:1>"
+        "supercategory": "<args:1>",
+        "append_to_existing_output": True
       }
     },
     {

--- a/src/renderer/SegMapRenderer.py
+++ b/src/renderer/SegMapRenderer.py
@@ -188,7 +188,9 @@ class SegMapRenderer(RendererInterface):
             used_attributes = self.config.get_raw_dict("map_by", "class")
 
             used_default_values = self.config.get_raw_dict("default_values", {})
-
+            if 'class' in used_default_values:
+                used_default_values['cp_category_id'] = used_default_values['class']
+                
             if isinstance(used_attributes, str):
                 # only one result is requested
                 result_channels = 1

--- a/src/utility/CocoUtility.py
+++ b/src/utility/CocoUtility.py
@@ -31,7 +31,9 @@ class CocoUtility:
                 inst_supercategory = inst["supercategory"]
                 
             if supercategory == inst_supercategory:
-                categories.append({'id': int(inst["category_id"]), 'name': inst["category_id"], 'supercategory': inst_supercategory})
+                cat_dict = {'id': int(inst["category_id"]), 'name': inst["category_id"], 'supercategory': inst_supercategory}
+                if cat_dict not in categories:
+                    categories.append(cat_dict)
                 instance_2_category_map[int(inst["idx"])] = int(inst["category_id"])
 
         licenses = [{
@@ -99,8 +101,11 @@ class CocoUtility:
         :param new_coco_annotations: A dict describing the second coco annotations.
         :return: A dict containing the merged coco annotations.
         """
-        if existing_coco_annotations["categories"] != new_coco_annotations["categories"]:
-            raise NotImplementedError("The existing coco annotations file contains different categories/objects than the current scene. Merging the two lists is not implemented yet.")
+
+        # Concatenate category sections
+        for cat_dict in new_coco_annotations["categories"]:
+            if cat_dict not in existing_coco_annotations["categories"]:
+                existing_coco_annotations["categories"].append(cat_dict)
 
         # Concatenate images sections
         image_id_offset = max([image["id"] for image in existing_coco_annotations["images"]]) + 1


### PR DESCRIPTION
- solves issue #43, i.e. adds merge functionality for coco categories
- allow default_value `"class"` as `"cp_category_id"`