### PR TITLE
fix(CocoUtility): Changed coco annotations area field to be float rather than list

### DIFF
--- a/src/utility/CocoUtility.py
+++ b/src/utility/CocoUtility.py
@@ -169,7 +169,7 @@ class CocoUtility:
             "image_id": image_id,
             "category_id": category_id,
             "iscrowd": 0,
-            "area": [area],
+            "area": area,
             "bbox": bounding_box,
             "segmentation": segmentation,
             "width": binary_mask.shape[1],


### PR DESCRIPTION


Area field was previously made to be a list of area which does not agree
with the official COCO specifications for how annotations are formatted.
This change enhances compatability with other tools such as the official
COCO API.

closes #48