### PR TITLE
fix typo in src_sampler_Sphere_py

### DIFF
--- a/src/provider/sampler/Sphere.py
+++ b/src/provider/sampler/Sphere.py
@@ -69,7 +69,7 @@ class Sphere(Provider):
             magnitude = radius
         # If sampling from the interior set it to scaled radius
         elif mode == "INTERIOR":
-            magnitude = radius * np.cbrt(np.random.unform())
+            magnitude = radius * np.cbrt(np.random.uniform())
         else:
             raise Exception("Unknown sampling mode: " + mode)
         


### PR DESCRIPTION
Hi,  
When I try this module in camera.CameraSample with mode="INTERIOR", it will raise the error `AttributeError: module 'numpy.random' has no attribute 'unform'`.
Here is the module I added to the pipeline.
```
{
  "module": "camera.CameraSampler",
  "config": {
    "cam_poses": [
      {
        "number_of_samples": 10,
        "location":{
          "provider":"sampler.Sphere",
          "center":[0, 0, 0],
          "radius": 2,
          "mode": "INTERIOR"
        },
        "rotation": {
          "format": "look_at",
          "value": [0,0,0],          
          "inplane_rot": {
            "provider": "sampler.Value",
            "type": "float",
            "min": -0.7854,
            "max": 0.7854
          }
        }
      }
    ]
  }
},  
```
