### PR TITLE
updated to allow the option of recording the alpha channel for a transparent background in renderings

### DIFF
--- a/examples/shapenet/README.md
+++ b/examples/shapenet/README.md
@@ -91,11 +91,26 @@ The position will be in the center of the scene.
 We sample here five random camera poses, where the location is on a sphere with a radius of 2 around the object. 
 Each cameras rotation is such that it looks directly at the object and the camera faces upwards in Z direction.
 
+
+## RGB Renderer
+```
+"module": "renderer.RgbRenderer",
+  "config": {
+    "transparent_background": False,
+    "render_normals": True,
+    "samples": 350,
+    "render_distance": true
+  }
+}
+```
+To render with a transparent background, specify `transparent_background` as True. 
+
+
 ## HD5 Writer
 ```
 "module": "writer.Hdf5Writer",
     "config": {
-    "store_alpha": False,
+    "transparent_background": False,
     "postprocessing_modules": {
       "distance": [
         {
@@ -106,21 +121,7 @@ Each cameras rotation is such that it looks directly at the object and the camer
     }
 }
 ```
-To store alpha values in the hd5 files, use the store_alpha parameter.
-
-## RGB Renderer
-```
-"module": "renderer.RgbRenderer",
-  "config": {
-    "transparent_background": False,
-    "render_alpha": False,
-    "render_normals": True,
-    "samples": 350,
-    "render_distance": true
-  }
-}
-```
-To render with alpha values, set render_alpha to True. To render a transparent background, set transparent_background to True.
+To write to a hd5 file with a transparent image backgound, specify transparent_background as True.
 
 ## More examples
 

--- a/examples/shapenet/README.md
+++ b/examples/shapenet/README.md
@@ -91,6 +91,37 @@ The position will be in the center of the scene.
 We sample here five random camera poses, where the location is on a sphere with a radius of 2 around the object. 
 Each cameras rotation is such that it looks directly at the object and the camera faces upwards in Z direction.
 
+## HD5 Writer
+```
+"module": "writer.Hdf5Writer",
+    "config": {
+    "store_alpha": False,
+    "postprocessing_modules": {
+      "distance": [
+        {
+          "module": "postprocessing.TrimRedundantChannels",
+          "config": {}
+        }
+      ]
+    }
+}
+```
+To store alpha values in the hd5 files, use the store_alpha parameter.
+
+## RGB Renderer
+```
+"module": "renderer.RgbRenderer",
+  "config": {
+    "transparent_background": False,
+    "render_alpha": False,
+    "render_normals": True,
+    "samples": 350,
+    "render_distance": true
+  }
+}
+```
+To render with alpha values, set render_alpha to True. To render a transparent background, set transparent_background to True.
+
 ## More examples
 
 * [sung_basic](../suncg_basic): More on rendering SUNCG scenes with fixed camera poses.

--- a/examples/shapenet/config.yaml
+++ b/examples/shapenet/config.yaml
@@ -20,7 +20,7 @@
       "module": "loader.ShapeNetLoader",
       "config": {
         "data_path": "<args:0>",
-        "used_synset_id": "03001627"
+        "used_synset_id": "02801938"
       }
     },
     {
@@ -61,7 +61,6 @@
       "module": "renderer.RgbRenderer",
       "config": {
         "transparent_background": False,
-        "render_alpha": False,
         "render_normals": True,
         "samples": 350,
         "render_distance": true
@@ -70,7 +69,7 @@
     {
       "module": "writer.Hdf5Writer",
       "config": {
-        "store_alpha": False,
+        "transparent_background": False,
         "postprocessing_modules": {
           "distance": [
             {

--- a/examples/shapenet/config.yaml
+++ b/examples/shapenet/config.yaml
@@ -20,7 +20,7 @@
       "module": "loader.ShapeNetLoader",
       "config": {
         "data_path": "<args:0>",
-        "used_synset_id": "02801938"
+        "used_synset_id": "03001627"
       }
     },
     {
@@ -60,6 +60,8 @@
     {
       "module": "renderer.RgbRenderer",
       "config": {
+        "transparent_background": False,
+        "render_alpha": False,
         "render_normals": True,
         "samples": 350,
         "render_distance": true
@@ -68,6 +70,7 @@
     {
       "module": "writer.Hdf5Writer",
       "config": {
+        "store_alpha": False,
         "postprocessing_modules": {
           "distance": [
             {

--- a/scripts/saveAsImg.py
+++ b/scripts/saveAsImg.py
@@ -44,6 +44,16 @@ def save_array_as_image(array, key, file_path):
         else:
             plt.imsave(file_path, val)
 
+    elif len(array.shape) == 3 and array.shape[2] == 4:
+        print("Saving image as RGBa (with alpha)")
+        val = process_img(array, key)
+        plt.imsave(file_path, val)
+
+    #error message if shape is incorrect
+    else:
+        print("Can't save numpy array with shape {} as an image".format(array.shape))
+
+
 
 def convert_hdf(base_file_path, output_folder=None):
     if os.path.exists(base_file_path):
@@ -64,6 +74,7 @@ def convert_hdf(base_file_path, output_folder=None):
                         if val.shape[0] != 2:
                             # mono image
                             file_path = '{}_{}.png'.format(base_name, key)
+                            print("saving to ", file_path)
                             save_array_as_image(val, key, file_path)
                         else:
                             # stereo image

--- a/src/renderer/RgbRenderer.py
+++ b/src/renderer/RgbRenderer.py
@@ -14,6 +14,7 @@ class RgbRenderer(RendererInterface):
         "render_texture_less", "Render all objects with a white slightly glossy texture, does not change emission "
                                 "materials, Type: bool. Default: False."
         "image_type", "Image type of saved rendered images, Type: str. Default: 'PNG'. Available: ['PNG','JPEG']"
+        "transparent_background", "Whether to render the background as transparent or not, Type: bool. Default: False."
     """
     def __init__(self, config):
         RendererInterface.__init__(self, config)
@@ -60,7 +61,7 @@ class RgbRenderer(RendererInterface):
 
             # In case a previous renderer changed these settings
             #Store as RGB by default unless the user specifies store_alpha as true in yaml
-            bpy.context.scene.render.image_settings.color_mode = "RGBA" if self.config.get_bool("render_alpha", False) else "RGB"
+            bpy.context.scene.render.image_settings.color_mode = "RGBA" if self.config.get_bool("transparent_background", False) else "RGB"
             #set the background as transparent if transparent_background is true in yaml
             bpy.context.scene.render.film_transparent = self.config.get_bool("transparent_background", False)
             bpy.context.scene.render.image_settings.file_format = self._image_type

--- a/src/renderer/RgbRenderer.py
+++ b/src/renderer/RgbRenderer.py
@@ -59,7 +59,10 @@ class RgbRenderer(RendererInterface):
             self._configure_renderer(use_denoiser=True, default_denoiser="Intel")
 
             # In case a previous renderer changed these settings
-            bpy.context.scene.render.image_settings.color_mode = "RGB"
+            #Store as RGB by default unless the user specifies store_alpha as true in yaml
+            bpy.context.scene.render.image_settings.color_mode = "RGBA" if self.config.get_bool("render_alpha", False) else "RGB"
+            #set the background as transparent if transparent_background is true in yaml
+            bpy.context.scene.render.film_transparent = self.config.get_bool("transparent_background", False)
             bpy.context.scene.render.image_settings.file_format = self._image_type
             bpy.context.scene.render.image_settings.color_depth = "8"
 

--- a/src/writer/WriterInterface.py
+++ b/src/writer/WriterInterface.py
@@ -24,8 +24,8 @@ class WriterInterface(Module):
                               "attributes that can be used here. Type: list."
        "output_file_prefix", "The prefix of the file that should be created. Type: string."
        "output_key", "The key which should be used for storing the output in a merged file. Type: string."
-       "transparent_background", "If true, the background will be set to transparent and the alpha channel will be "
-                                "written to file. Type: bool. Default: False."
+       "transparent_background", "If true, the alpha channel will be written to file. Type: bool. Default: False."
+                                
     """
     def __init__(self, config):
         Module.__init__(self, config)

--- a/src/writer/WriterInterface.py
+++ b/src/writer/WriterInterface.py
@@ -24,6 +24,8 @@ class WriterInterface(Module):
                               "attributes that can be used here. Type: list."
        "output_file_prefix", "The prefix of the file that should be created. Type: string."
        "output_key", "The key which should be used for storing the output in a merged file. Type: string."
+       "transparent_background", "If true, the background will be set to transparent and the alpha channel will be "
+                                "written to file. Type: bool. Default: False."
     """
     def __init__(self, config):
         Module.__init__(self, config)
@@ -132,8 +134,8 @@ class WriterInterface(Module):
         file_ending = file_path[file_path.rfind(".") + 1:].lower()
 
         if file_ending in ["exr", "png", "jpg"]:
-            #no_channels is 4 if store_alpha is true in config
-            return load_image(file_path, num_channels = 3 + self.config.get_bool("store_alpha", False))
+            #num_channels is 4 if transparent_background is true in config
+            return load_image(file_path, num_channels = 3 + self.config.get_bool("transparent_background", False))
         elif file_ending in ["npy", "npz"]:
             return self._load_npy(file_path)
         elif file_ending in ["csv"]:

--- a/src/writer/WriterInterface.py
+++ b/src/writer/WriterInterface.py
@@ -132,7 +132,8 @@ class WriterInterface(Module):
         file_ending = file_path[file_path.rfind(".") + 1:].lower()
 
         if file_ending in ["exr", "png", "jpg"]:
-            return load_image(file_path)
+            #no_channels is 4 if store_alpha is true in config
+            return load_image(file_path, num_channels = 3 + self.config.get_bool("store_alpha", False))
         elif file_ending in ["npy", "npz"]:
             return self._load_npy(file_path)
         elif file_ending in ["csv"]:


### PR DESCRIPTION
Details of how to include/exclude the parameters to write the alpha channel in examples/shapenet/README.md. Related to #71 