### PR TITLE
[Doc] Update docstring for ObjectPoseSamplerModule

### DIFF
--- a/src/object/ObjectPoseSamplerModule.py
+++ b/src/object/ObjectPoseSamplerModule.py
@@ -22,7 +22,7 @@ class ObjectPoseSamplerModule(Module):
             "max_iterations": 1000,
             "objects_to_sample": {
               "provider": "getter.Entity",
-              "condition": {
+              "conditions": {
                 "cp_sample_pose": True
               }
             },


### PR DESCRIPTION
Following Example1 in:
https://dlr-rm.github.io/BlenderProc/src.object.ObjectPoseSamplerModule.html

results in every object in scene having their pose always randomized, due to the typo "condition"(x) ->  "conditions" (o) in the objects_to_sample provider