### PR TITLE
Fix the logic to determine Blender major version

### DIFF
--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -79,7 +79,7 @@ class InstallUtility:
                 blender_install_path = "blender"
 
             # Determine configured version
-            # right new only support blender-2.93
+            # right now only support blender-2.93
             major_version = "2.93"
             minor_version = "0"
             blender_version = "blender-{}.{}".format(major_version, minor_version)
@@ -183,11 +183,14 @@ class InstallUtility:
 
             # Try to get major version of given blender installation
             major_version = None
-            for sub_dir in os.listdir(blender_path):
+            for root, sub_dirs, files in os.walk(blender_path):
                 # Search for the subdirectory which has the major version as its name
-                if os.path.isdir(os.path.join(blender_path, sub_dir)) and sub_dir.replace(".", "").isdigit():
-                    major_version = sub_dir
-                    break
+                # Note: For Blender (2.93.5 2021-10-06 arm64) on MacOS the dir is "/Applications/Blender.app/Contents/Resources/2.93/"
+                # That's why we need to search all the subdirectories recursively to find major version
+                for sub_dir in sub_dirs:
+                    if sub_dir.replace(".", "").isdigit():
+                        major_version = sub_dir
+                        break
 
             if major_version is None:
                 raise Exception("Could not determine major blender version")


### PR DESCRIPTION
## Actual result
Running the following command would cause error `Exception: Could not determine major blender version`
```bash
blenderproc run examples/basics/basic/main.py examples/resources/camera_positions examples/resources/scene.obj examples/basics/basic/output --custom-blender-path /Applications/Blender.app/
```

Detailed error messages:
```
Traceback (most recent call last):
  File "/Users/martinku/mambaforge/envs/sock-vision/bin/blenderproc", line 33, in <module>
    sys.exit(load_entry_point('blenderproc', 'console_scripts', 'blenderproc')())
  File "/Users/martinku/Documents/Projects/BlenderProc/blenderproc/command_line.py", line 90, in cli
    blender_run_path, _ = InstallUtility.make_sure_blender_is_installed(custom_blender_path, blender_install_path, args.reinstall_blender)
  File "/Users/martinku/Documents/Projects/BlenderProc/blenderproc/python/utility/InstallUtility.py", line 193, in make_sure_blender_is_installed
    raise Exception("Could not determine major blender version")
Exception: Could not determine major blender version
```

## Expected result
By searching the version directory recursively, it should find the major version and not raising the error.

## Environment info
Hardware: Macbook Air (M1, 2020) with Apple M1
OS: macOS 12.0.1
Blender version: 2.93.5 (hash a791bdabd0b2 built 2021-10-06 06:22:05)