### PR TITLE
fix(utility): Set correct blender_run_path

### DIFF
--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -200,7 +200,7 @@ class InstallUtility:
         elif platform == "darwin":
             blender_run_path = os.path.join(blender_path, "Contents", "MacOS", "Blender")
         elif platform == "win32":
-            blender_run_path = os.path.join(blender_install_path, "blender-windows64", "blender")
+            blender_run_path = os.path.join(blender_install_path, blender_version, "blender")
         else:
             raise Exception("This system is not supported yet: {}".format(platform))
 


### PR DESCRIPTION
Since version 2.93.1 the subfolder of the .zip portable
installation for Windows is no longer called "blender-windows64",
but "blender-{major}.{minor}-windows-x64". This commit sets the
correct blender_run_path for Windows and blender version > 2.93.
If at some point, downwards compatibilty of BlenderProc to older
Blender versions is implemented, the assignment of blender_run_path
has to be adjusted accordingly to account for the different naming
conventions by Blender.

closes #412