### PR TITLE
fix(types): Do not apply `scale` twice on primitive

### DIFF
--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -517,7 +517,8 @@ def create_primitive(shape: str, **kwargs) -> "MeshObject":
         raise Exception("No such shape: " + shape)
 
     primitive = MeshObject(bpy.context.object)
-    # Blender bug: Scale is ignored by default for planes and monkeys. #1060
+    # Blender bug: Scale is ignored by default for planes and monkeys.
+    # See https://developer.blender.org/T88047
     if 'scale' in kwargs and shape in ["MONKEY", "PLANE"]:
         primitive.set_scale(kwargs['scale'])
 

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -516,7 +516,12 @@ def create_primitive(shape: str, **kwargs) -> "MeshObject":
     else:
         raise Exception("No such shape: " + shape)
 
-    return MeshObject(bpy.context.object)
+    primitive = MeshObject(bpy.context.object)
+    # Blender bug: Scale is ignored by default for planes and monkeys. #1060
+    if 'scale' in kwargs and shape in ["MONKEY", "PLANE"]:
+        primitive.set_scale(kwargs['scale'])
+
+    return primitive
 
 
 def convert_to_meshes(blender_objects: list) -> List["MeshObject"]:

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -498,7 +498,7 @@ def create_with_empty_mesh(object_name: str, mesh_name: str = None) -> "MeshObje
 def create_primitive(shape: str, **kwargs) -> "MeshObject":
     """ Creates a new primitive mesh object.
 
-    :param shape: The name of the primitive to create. Available: ["CUBE"]
+    :param shape: The name of the primitive to create. Available: ["CUBE", "CYLINDER", "CONE", "PLANE", "SPHERE", "MONKEY"]
     :return:
     """
     if shape == "CUBE":

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -499,7 +499,7 @@ def create_primitive(shape: str, **kwargs) -> "MeshObject":
     """ Creates a new primitive mesh object.
 
     :param shape: The name of the primitive to create. Available: ["CUBE", "CYLINDER", "CONE", "PLANE", "SPHERE", "MONKEY"]
-    :return:
+    :return: The newly created MeshObject
     """
     if shape == "CUBE":
         bpy.ops.mesh.primitive_cube_add(**kwargs)

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -516,12 +516,7 @@ def create_primitive(shape: str, **kwargs) -> "MeshObject":
     else:
         raise Exception("No such shape: " + shape)
 
-    primitive = MeshObject(bpy.context.object)
-    # Blender bug: Scale is ignored by default. #1060
-    if 'scale' in kwargs:
-        primitive.set_scale(kwargs['scale'])
-
-    return primitive
+    return MeshObject(bpy.context.object)
 
 
 def convert_to_meshes(blender_objects: list) -> List["MeshObject"]:


### PR DESCRIPTION
Up to now, `scale` is applied in `create_primitive()` to the
primitive after its creation. The reason for this was a bug in
Blender which ignored the `scale` argument in
`bpy.ops.mesh.primitive_..._add()`. This seems to be fixed by now,
so the scaling inside BlenderProc results in applying the scaling
twice.

This commit fixes this bug in BlenderProc by deleting the second
scaling.

fixes #432 