### PR TITLE
feat: Add local build folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
 */__pycache__
+blenderproc.egg-info/
+build/
 blender
 .idea/
 .vscode/


### PR DESCRIPTION
When using a local installation (via `pip install [-e] .`), the
folders `blenderpoc.egg-info/` and `build/` are created, which
should not be tracked by git.

Fixes #439