### PR TITLE
Add semantic information from json

### DIFF
--- a/blenderproc/python/loader/Front3DLoader.py
+++ b/blenderproc/python/loader/Front3DLoader.py
@@ -16,9 +16,7 @@ from blenderproc.python.utility.Utility import resolve_path
 from blenderproc.python.loader.ObjectLoader import load_obj
 from blenderproc.python.loader.TextureLoader import load_texture
 
-
 def load_front3d(json_path: str, future_model_path: str, front_3D_texture_path: str, label_mapping: LabelIdMapping,
-                 ceiling_light_strength: float = 0.8, lamp_light_strength: float = 7.0) -> List[MeshObject]:
                  ceiling_light_strength: float = 0.8, lamp_light_strength: float = 7.0, 
                  random_light_color: bool = False, random_light_intensity: bool = False) -> List[MeshObject]:
     """ Loads the 3D-Front scene specified by the given json file.

--- a/blenderproc/python/loader/Front3DLoader.py
+++ b/blenderproc/python/loader/Front3DLoader.py
@@ -392,6 +392,8 @@ class Front3DLoader:
         blender_rot_mat = mathutils.Matrix.Rotation(radians(-90), 4, 'X')
         created_objects = []
                                 
+        equal_objs = []
+        prev_uid = ''
         # for each room
         for room_id, room in enumerate(data["scene"]["room"]):
             # for each object in that room
@@ -406,7 +408,6 @@ class Front3DLoader:
                             else:
                                 # if it is the first time use the object directly
                                 new_obj = obj
-                            created_objects.append(new_obj)
                             new_obj.set_cp("is_used", True)
                             new_obj.set_cp("room_id", room_id)
                             new_obj.set_cp("type", "Object")  # is an object used for the interesting score
@@ -443,4 +444,7 @@ class Front3DLoader:
                     bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY', center='MEDIAN')
 
                     created_objects.append(i[0])
+                    print("JOINED")
+                    bpy.ops.object.join()
+
         return created_objects

--- a/examples/datasets/front_3d/main.py
+++ b/examples/datasets/front_3d/main.py
@@ -27,7 +27,9 @@ loaded_objects = bproc.loader.load_front3d(
     json_path=args.front,
     future_model_path=args.future_folder,
     front_3D_texture_path=args.front_3D_texture_path,
-    label_mapping=mapping
+    label_mapping=mapping,
+    random_light_color=True,
+    random_light_intensity=True
 )
 
 # Init sampler for sampling locations inside the loaded front3D house

--- a/examples/datasets/front_3d_with_improved_mat/main.py
+++ b/examples/datasets/front_3d_with_improved_mat/main.py
@@ -29,7 +29,9 @@ loaded_objects = bproc.loader.load_front3d(
     json_path=args.front,
     future_model_path=args.future_folder,
     front_3D_texture_path=args.front_3D_texture_path,
-    label_mapping=mapping
+    label_mapping=mapping,
+    random_light_color=True,
+    random_light_intensity=True
 )
 
 cc_materials = bproc.loader.load_ccmaterials(args.cc_material_path, ["Bricks", "Wood", "Carpet", "Tile", "Marble"])


### PR DESCRIPTION
Use front_3d provided json for semantic info.

This can be wrong, as noted in #430. However, a strategy might be to maintain both the old id and the new one, until this is fixed in the released data itself.