### PR TITLE
feat(scale_uvs): add scale_uv_coordinates() to MeshObject class

### DIFF
--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -436,6 +436,21 @@ class MeshObject(Entity):
             return max_val > 1e-7
         return False
 
+    def scale_uv_coordinates(self, factor: float):
+        """Scales the UV coordinates of an object by a given factor. Scaling with a factor greater than one has the 
+        effect of making the texture look smaller on the object.
+
+        :param factor: The amount the UV coordinates will be scaled.
+        :type factor: float
+        """
+        if not self.has_uv_mapping():
+            raise Exception("Cannot scale UV coordinates of a MeshObject that has no UV mapping.")
+
+        mesh = self.blender_obj.data
+        uv_layer = mesh.uv_layers.active
+        for loop in mesh.loops :
+            uv_layer.data[loop.index].uv *= factor
+        
     def add_displace_modifier(self, texture: bpy.types.Texture, mid_level: float = 0.5, strength: float = 0.1,
                               min_vertices_for_subdiv: int = 10000, subdiv_level: int = 2):
         """ Adds a displace modifier with a texture to an object.


### PR DESCRIPTION
New function that allows you to easily scale the UV coordinates of a MeshObject. Increasing UV scale, decreases the size of the texture on an object.

closes #476