### PR TITLE
Fix(BOP): Reset max samples to 50

### DIFF
--- a/examples/datasets/bop_challenge/main_hb_random.py
+++ b/examples/datasets/bop_challenge/main_hb_random.py
@@ -58,6 +58,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering without antialiasing and set amount of samples for color rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 for i in range(args.num_scenes):
 

--- a/examples/datasets/bop_challenge/main_icbin_random.py
+++ b/examples/datasets/bop_challenge/main_icbin_random.py
@@ -56,6 +56,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering without antialiasing and set amount of samples for color rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 for i in range(args.num_scenes):
 

--- a/examples/datasets/bop_challenge/main_itodd_random.py
+++ b/examples/datasets/bop_challenge/main_itodd_random.py
@@ -56,6 +56,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering without antialiasing and set amount of samples for color rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 for i in range(args.num_scenes):
 

--- a/examples/datasets/bop_challenge/main_lm_upright.py
+++ b/examples/datasets/bop_challenge/main_lm_upright.py
@@ -56,6 +56,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering without antialiasing and set amount of samples for color rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 for i in range(args.num_scenes):
 

--- a/examples/datasets/bop_challenge/main_tless_random.py
+++ b/examples/datasets/bop_challenge/main_tless_random.py
@@ -58,6 +58,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering without antialiasing and set amount of samples for color rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 for i in range(args.num_scenes):
 

--- a/examples/datasets/bop_challenge/main_tudl_random.py
+++ b/examples/datasets/bop_challenge/main_tudl_random.py
@@ -58,6 +58,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering without antialiasing and set amount of samples for color rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 for i in range(args.num_scenes):
 

--- a/examples/datasets/bop_challenge/main_ycbv_random.py
+++ b/examples/datasets/bop_challenge/main_ycbv_random.py
@@ -58,6 +58,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering without antialiasing and set amount of samples for color rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 for i in range(args.num_scenes):
 

--- a/examples/datasets/bop_object_on_surface_sampling/main.py
+++ b/examples/datasets/bop_object_on_surface_sampling/main.py
@@ -112,6 +112,7 @@ while poses < 10:
 
 # activate depth rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 # render the whole pipeline
 data = bproc.renderer.render()

--- a/examples/datasets/bop_object_physics_positioning/main.py
+++ b/examples/datasets/bop_object_physics_positioning/main.py
@@ -122,6 +122,7 @@ while poses < 10:
 
 # activate depth rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 # render the whole pipeline
 data = bproc.renderer.render()

--- a/examples/datasets/bop_object_pose_sampling/main.py
+++ b/examples/datasets/bop_object_pose_sampling/main.py
@@ -37,6 +37,7 @@ def sample_pose_func(obj: bproc.types.MeshObject):
     
 # activate depth rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 # Render five different scenes
 for _ in range(5):

--- a/examples/datasets/bop_scene_replication/main.py
+++ b/examples/datasets/bop_scene_replication/main.py
@@ -27,6 +27,7 @@ light_point.set_location([0, 0, -0.8])
 
 # activate depth rendering
 bproc.renderer.enable_depth_output(activate_antialiasing=False)
+bproc.renderer.set_max_amount_of_samples(50)
 
 # render the cameras of the current scene
 data = bproc.renderer.render()


### PR DESCRIPTION
#485 

This should reduce the rendering time a lot and allows generating the original BOP data.