### PR TITLE
Resume cctexture download

### DIFF
--- a/blenderproc/scripts/download_cc_textures.py
+++ b/blenderproc/scripts/download_cc_textures.py
@@ -8,6 +8,11 @@ import requests
 import argparse
 
 from blenderproc.python.utility.SetupUtility import SetupUtility
+from requests.adapters import HTTPAdapter
+
+session = requests.Session()
+session.mount('http://', HTTPAdapter(max_retries=3))
+session.mount('https://', HTTPAdapter(max_retries=3))
 
 def cli():
     parser = argparse.ArgumentParser("Downloads textures from cc0textures.com")
@@ -20,15 +25,18 @@ def cli():
     }
 
     cc_texture_dir = args.output_dir
+    csv_file_path = os.path.join(cc_texture_dir, "full_info.csv")
     if not os.path.exists(cc_texture_dir):
         os.makedirs(cc_texture_dir)
     else:
-        raise Exception("The folder already exists!")
+        if os.path.isfile(csv_file_path):
+            print("Resume previous download")
+        else:
+            raise Exception("The folder already exists and does not contain cc_textures!")
 
     # download the csv file, which contains all the download links
     csv_url = "https://cc0textures.com/api/v1/downloads_csv"
-    csv_file_path = os.path.join(cc_texture_dir, "full_info.csv")
-    request = requests.get(csv_url, headers=headers)
+    request = session.get(csv_url, headers=headers)
     with open(csv_file_path, "wb") as file:
         file.write(request.content)
 
@@ -53,14 +61,22 @@ def cli():
                 break
         if do_not_use:
             continue
-        print("Download asset: {} of {}/{}".format(asset, index, len(data)))
         current_folder =  os.path.join(cc_texture_dir, asset)
         if not os.path.exists(current_folder):
             os.makedirs(current_folder)
-        current_file_path = os.path.join(current_folder, "{}.zip".format(asset))
-        response = requests.get(link, headers=headers)
-        SetupUtility.extract_from_response(current_folder, response)
-
+        elif os.listdir(current_folder):
+            print("Already downloaded asset: {} of {}/{}".format(asset, index + 1, len(data)))
+            continue
+        try:
+            response = session.get(link, headers=headers, timeout=20)
+        except Exception as e:
+            print(f"Get response from link:{link} failed, with error:{e}")
+            raise e
+        try:
+            SetupUtility.extract_from_response(current_folder, response)
+        except Exception as e:
+            print(f"Cannot extract texture, because:{e}")
+        print("Download and extract asset: {} of {}/{}".format(asset, index + 1, len(data)))
     print("Done downloading textures, saved in {}".format(cc_texture_dir))
 
 if __name__ == "__main__":

--- a/examples/datasets/bop_challenge/main_lm_upright.py
+++ b/examples/datasets/bop_challenge/main_lm_upright.py
@@ -2,6 +2,7 @@ import blenderproc as bproc
 import argparse
 import os
 import numpy as np
+import time
 
 parser = argparse.ArgumentParser()
 parser.add_argument('bop_parent_path', help="Path to the bop datasets parent directory")
@@ -9,6 +10,8 @@ parser.add_argument('cc_textures_path', default="resources/cctextures", help="Pa
 parser.add_argument('output_dir', help="Path to where the final files will be saved ")
 parser.add_argument('--num_scenes', type=int, default=2000, help="How many scenes with 25 images each to generate")
 args = parser.parse_args()
+
+start_time = time.time()
 
 bproc.init()
 
@@ -148,3 +151,6 @@ for i in range(args.num_scenes):
     
     for obj in (sampled_target_bop_objs + sampled_distractor_bop_objs):      
         obj.hide(True)
+
+
+print(f"Render args.num_scenes*25 = {args.num_scenes * 25} ; Used time: {time.time() - start_time}")


### PR DESCRIPTION
Since when download cctexture always abort sometimes with internet issue， sometimes the request target is not a zip file and the script raises an exception.
I add two features:
1. use a socket session to request and setting the retry as 3 times in one request
2. ignore un-zip file after download

another change just add a time record in generate linemod scripts