### PR TITLE
Iss 513 switch to blender 3.1

### DIFF
--- a/blenderproc/__init__.py
+++ b/blenderproc/__init__.py
@@ -42,7 +42,10 @@ else:
         is_correct_startup_command = is_bproc_shell_called or is_command_line_script_called
     else:
         first_file_name = file_names_of_stack[0]
-        # check if the name of this file is either blenderproc or if the "OUTSIDE_OF_THE_INTERNAL_BLENDER_PYTHON_ENVIRONMENT_BUT_IN_RUN_SCRIPT" is set, which is set in the cli.py
+        # check if the name of this file is either blenderproc or if the
+        # "OUTSIDE_OF_THE_INTERNAL_BLENDER_PYTHON_ENVIRONMENT_BUT_IN_RUN_SCRIPT" is set, which is set in the cli.py
         is_correct_startup_command = first_file_name in ["blenderproc", "command_line.py"]
-    if "OUTSIDE_OF_THE_INTERNAL_BLENDER_PYTHON_ENVIRONMENT_BUT_IN_RUN_SCRIPT" not in os.environ and not is_correct_startup_command:
-        raise Exception(f"\n###############\nThis script can only be run by \"blenderproc run\", instead of calling:\n\tpython {sys.argv[0]}\ncall:\n\tblenderproc run {sys.argv[0]}\n###############")
+    if "OUTSIDE_OF_THE_INTERNAL_BLENDER_PYTHON_ENVIRONMENT_BUT_IN_RUN_SCRIPT" not in os.environ \
+            and not is_correct_startup_command:
+        raise Exception("\n###############\nThis script can only be run by \"blenderproc run\", instead of calling:"
+                        "\n\tpython {}\ncall:\n\tblenderproc run {}\n###############".format(sys.argv[0], sys.argv[0]))

--- a/blenderproc/external/vhacd/decompose.py
+++ b/blenderproc/external/vhacd/decompose.py
@@ -61,7 +61,7 @@ def convex_decomposition(obj: "MeshObject", temp_dir: str, vhacd_path: str, reso
     if not os.path.exists(os.path.join(vhacd_path, "v-hacd")):
         os.makedirs(vhacd_path, exist_ok=True)
         print("Downloading v-hacd library into " + str(vhacd_path))
-        git.Git(vhacd_path).clone("git://github.com/kmammou/v-hacd.git")
+        git.Git(vhacd_path).clone("https://github.com/kmammou/v-hacd.git")
 
         print("Building v-hacd")
         if "NO_OPENCL" in os.environ and os.environ["NO_OPENCL"] == "1":

--- a/blenderproc/python/camera/LensDistortionUtility.py
+++ b/blenderproc/python/camera/LensDistortionUtility.py
@@ -169,7 +169,7 @@ def set_lens_distortion(k1: float, k2: float, k3: float = 0.0, p1: float = 0.0, 
     cx_new += 1
     cy_new += 1
     # suggested resolution for Blender image generation
-    new_image_resolution = np.array([columns_needed, rows_needed])
+    new_image_resolution = np.array([columns_needed, rows_needed], dtype=int)
 
     # Adapt/shift the mapping function coordinates to the new_image_resolution resolution
     # (if we didn't, the mapping would only be valid for same resolution mapping)

--- a/blenderproc/python/modules/renderer/RendererInterface.py
+++ b/blenderproc/python/modules/renderer/RendererInterface.py
@@ -4,6 +4,7 @@ import bpy
 from blenderproc.python.modules.main.Module import Module
 from blenderproc.python.modules.utility.Config import Config
 import blenderproc.python.renderer.RendererUtility as RendererUtility
+from blenderproc.python.utility.DefaultConfig import DefaultConfig
 
 
 class RendererInterface(Module):
@@ -166,7 +167,7 @@ class RendererInterface(Module):
                 self._determine_output_dir(),
                 self.config.get_string("distance_output_file_prefix", "distance_"),
                 self.config.get_string("distance_output_key", "distance"),
-                self.config.get_float("distance_range", 10000.0)
+                self.config.get_float("distance_range", DefaultConfig.antialiasing_distance_max)
             )
 
         if self.config.get_bool("render_depth", False):

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -205,6 +205,7 @@ def enable_distance_output(activate_antialiasing: bool, output_dir: Optional[str
     mapper_node = tree.nodes.new("CompositorNodeMapRange")
     links.new(render_layer_node.outputs["Mist"], mapper_node.inputs['Value'])
     # map the values 0-1 to range distance_start to distance_range
+    mapper_node.inputs['From Max'].default_value = 1.0
     mapper_node.inputs['To Min'].default_value = 0
     mapper_node.inputs['To Max'].default_value = antialiasing_distance_max
     final_output = mapper_node.outputs['Value']

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -37,7 +37,5 @@ class DefaultConfig:
     antialiasing_distance_max = 10000
 
     # Setup
-    #default_pip_packages = ["wheel", "pyyaml==6.0", "imageio==2.16.1", "gitpython==3.1.27", "scikit-image==0.19.2", "pypng==0.0.21", "scipy==1.8.0", "tkinter",
-    #                        "matplotlib==3.4.3", "pytz==2021.3", "h5py==3.6.0", "Pillow==9.0.1", "opencv-contrib-python==4.5.5.64", "scikit-learn==1.0.2"]
     default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", "gitpython==3.1.18", "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3",
                             "matplotlib==3.5.1", "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64", "scikit-learn==1.0.2"]

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -37,5 +37,7 @@ class DefaultConfig:
     antialiasing_distance_max = 10000
 
     # Setup
-    default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", "gitpython==3.1.18", "scikit-image==0.18.3", "pypng==0.0.20", "scipy==1.7.1",
-                            "matplotlib==3.4.3", "pytz==2021.1", "h5py==3.4.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.3.56", "scikit-learn==0.24.2"]
+    #default_pip_packages = ["wheel", "pyyaml==6.0", "imageio==2.16.1", "gitpython==3.1.27", "scikit-image==0.19.2", "pypng==0.0.21", "scipy==1.8.0", "tkinter",
+    #                        "matplotlib==3.4.3", "pytz==2021.3", "h5py==3.6.0", "Pillow==9.0.1", "opencv-contrib-python==4.5.5.64", "scikit-learn==1.0.2"]
+    default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", "gitpython==3.1.18", "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3",
+                            "matplotlib==3.5.1", "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64", "scikit-learn==1.0.2"]

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -38,4 +38,5 @@ class DefaultConfig:
 
     # Setup
     default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", "gitpython==3.1.18", "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3",
-                            "matplotlib==3.5.1", "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64", "scikit-learn==1.0.2"]
+                            "matplotlib==3.5.1", "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64", "scikit-learn==1.0.2",
+                            "python-dateutil==2.8.2"]

--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -2,6 +2,7 @@ import os
 import random
 from numpy import random as np_random
 from sys import platform
+
 import multiprocessing
 
 import bpy
@@ -37,9 +38,28 @@ def init(horizon_color: list = [0.05, 0.05, 0.05], compute_device: str = "GPU", 
     bpy.context.scene.render.engine = 'CYCLES'
 
     if platform == "darwin" or compute_device == "CPU":
-        # if there is no gpu support (mac os) or if cpu is specified as compute device, then use the cpu with maximum power
-        bpy.context.scene.cycles.device = "CPU"
-        bpy.context.scene.render.threads = multiprocessing.cpu_count()
+        import platform as platform_locally
+        mac_version = platform_locally.mac_ver()[0]
+        mac_version_numbers = [int(ele) for ele in mac_version.split(".")]
+        if (mac_version_numbers[0] == 12 and mac_version_numbers[1] >= 3) or mac_version_numbers[0] > 12:
+            bpy.context.scene.cycles.device = "GPU"
+            preferences = bpy.context.preferences.addons['cycles'].preferences
+            for device_type in preferences.get_device_types(bpy.context):
+                preferences.get_devices_for_type(device_type[0])
+            gpu_type = "METAL"  # only available type on mac os
+            for device in preferences.devices:
+                if device.type == gpu_type and (compute_device_type is None or compute_device_type == gpu_type):
+                    bpy.context.preferences.addons['cycles'].preferences.compute_device_type = gpu_type
+                    print('Device {} of type {} found and used.'.format(device.name, device.type))
+                    break
+            # make sure that all visible GPUs are used
+            for device in prefs.devices:
+                device.use = True
+        else:
+            # there is no gpu support on mac os below 12.3, if cpu is specified as compute device,
+            # then we use the cpu with maximum power
+            bpy.context.scene.cycles.device = "CPU"
+            bpy.context.scene.render.threads = multiprocessing.cpu_count()
     else:
         bpy.context.scene.cycles.device = "GPU"
         preferences = bpy.context.preferences.addons['cycles'].preferences

--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -37,7 +37,7 @@ def init(horizon_color: list = [0.05, 0.05, 0.05], compute_device: str = "GPU", 
     # Use cycles
     bpy.context.scene.render.engine = 'CYCLES'
 
-    if platform == "darwin" or compute_device == "CPU":
+    if platform == "darwin":
         import platform as platform_locally
         mac_version = platform_locally.mac_ver()[0]
         mac_version_numbers = [int(ele) for ele in mac_version.split(".")]
@@ -60,6 +60,9 @@ def init(horizon_color: list = [0.05, 0.05, 0.05], compute_device: str = "GPU", 
             # then we use the cpu with maximum power
             bpy.context.scene.cycles.device = "CPU"
             bpy.context.scene.render.threads = multiprocessing.cpu_count()
+    elif compute_device == "CPU":
+        bpy.context.scene.cycles.device = "CPU"
+        bpy.context.scene.render.threads = multiprocessing.cpu_count()
     else:
         bpy.context.scene.cycles.device = "GPU"
         preferences = bpy.context.preferences.addons['cycles'].preferences

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -79,8 +79,8 @@ class InstallUtility:
                 blender_install_path = "blender"
 
             # Determine configured version
-            # right new only support blender-2.93
-            major_version = "3.0"
+            # right new only support blender-3.1.0
+            major_version = "3.1"
             minor_version = "0"
             blender_version = "blender-{}.{}".format(major_version, minor_version)
             if platform == "linux" or platform == "linux2":

--- a/blenderproc/python/utility/SetupUtility.py
+++ b/blenderproc/python/utility/SetupUtility.py
@@ -83,16 +83,17 @@ class SetupUtility:
             major_version = os.path.basename(os.path.abspath(os.path.join(os.path.dirname(sys.executable), "..", "..")))
 
         # Based on the OS determined the three paths
+        current_python_version = "python3.10"
         if platform == "linux" or platform == "linux2":
             python_bin_folder = os.path.join(blender_path, major_version, "python", "bin")
-            python_bin = os.path.join(python_bin_folder, "python3.9")
+            python_bin = os.path.join(python_bin_folder, current_python_version)
             packages_path = os.path.abspath(os.path.join(blender_path, "custom-python-packages"))
-            pre_python_package_path = os.path.join(blender_path, major_version, "python", "lib", "python3.9", "site-packages")
+            pre_python_package_path = os.path.join(blender_path, major_version, "python", "lib", current_python_version, "site-packages")
         elif platform == "darwin":
             python_bin_folder = os.path.join(blender_path, "..", "Resources", major_version, "python", "bin")
-            python_bin = os.path.join(python_bin_folder, "python3.9")
+            python_bin = os.path.join(python_bin_folder, current_python_version)
             packages_path = os.path.abspath(os.path.join(blender_path, "custom-python-packages"))
-            pre_python_package_path = os.path.join(blender_path, "..", "Resources", major_version, "python", "lib", "python3.9", "site-packages")
+            pre_python_package_path = os.path.join(blender_path, "..", "Resources", major_version, "python", "lib", current_python_version, "site-packages")
         elif platform == "win32":
             python_bin_folder = os.path.join(blender_path, major_version, "python", "bin")
             python_bin = os.path.join(python_bin_folder, "python")

--- a/blenderproc/python/writer/GifWriterUtility.py
+++ b/blenderproc/python/writer/GifWriterUtility.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import bpy
 import numpy as np
-import matplotlib.pyplot as plt
 
 from blenderproc.scripts.visHdf5Files import vis_data
 from blenderproc.python.utility.Utility import Utility

--- a/blenderproc/scripts/visHdf5Files.py
+++ b/blenderproc/scripts/visHdf5Files.py
@@ -1,6 +1,7 @@
 import os
 import h5py
 import argparse
+from pathlib import Path
 import numpy as np
 from matplotlib import pyplot as plt
 import sys
@@ -179,7 +180,9 @@ def vis_file(path, keys_to_visualize=None, rgb_keys=None, flow_keys=None, segmap
                     if len(value.shape) >= 3 and value.shape[0] == 2:
                         # Visualize both eyes separately
                         for i, img in enumerate(value):
-                            vis_data(key, img, data, os.path.basename(path) + (" (left)" if i == 0 else " (right)"), rgb_keys, flow_keys, segmap_keys, segcolormap_keys, depth_keys, depth_max, save_to_file)
+                            used_save_to_file = str(Path(save_to_file).with_suffix("")) + (
+                                "_left" if i == 0 else "_right") + Path(save_to_file).suffix
+                            vis_data(key, img, data, os.path.basename(path) + (" (left)" if i == 0 else " (right)"), rgb_keys, flow_keys, segmap_keys, segcolormap_keys, depth_keys, depth_max, used_save_to_file)
                     else:
                         vis_data(key, value, data, os.path.basename(path), rgb_keys, flow_keys, segmap_keys, segcolormap_keys, depth_keys, depth_max, save_to_file)
         else:

--- a/examples/basics/material_manipulation/config.yaml
+++ b/examples/basics/material_manipulation/config.yaml
@@ -60,18 +60,6 @@
         "selector": {
           "provider": "getter.Material",
           "conditions": {
-            "name": "Material.001"
-          }
-        },
-        "cf_color_link_to_displacement": 1.5
-      }
-    },
-    {
-      "module": "manipulators.MaterialManipulator",
-      "config": {
-        "selector": {
-          "provider": "getter.Material",
-          "conditions": {
             "name": "Material.*"
           }
         },
@@ -82,6 +70,18 @@
             "path": "<args:1>/material_manipulation_sample_texture*.jpg"
           }
         }
+      }
+    },
+    {
+      "module": "manipulators.MaterialManipulator",
+      "config": {
+        "selector": {
+          "provider": "getter.Material",
+          "conditions": {
+            "name": "Material.001"
+          }
+        },
+        "cf_color_link_to_displacement": 1.5
       }
     },
     {


### PR DESCRIPTION
Fixes #513 

* switches to blender 3.1 and python 3.10
* raises version numbers on used python packages
* add gpu support for METAL on mac os above 12.3

- [x] tested on linux
- [x] tested on mac os
- [x] tested on windows