### PR TITLE
fix(segmaprenderer): fix too many objects in seg scene

### DIFF
--- a/blenderproc/python/renderer/SegMapRendererUtility.py
+++ b/blenderproc/python/renderer/SegMapRendererUtility.py
@@ -266,6 +266,12 @@ def _colorize_object(obj: bpy.types.Object, color: mathutils.Vector, use_alpha_c
     # Create new material emitting the given color
     new_mat = bpy.data.materials.new(name="segmentation")
     new_mat.use_nodes = True
+    # sampling as light,conserves memory, by not keeping a referennce to it for multiple importance sampling.
+    # This shouldn't change the results because with an emmission of 1 the colorized objects aren't emmitting light.
+    # Also blenderproc's segmap render settings are configured so that there is only a single sample to distribute, 
+    # multiple importance shouldn't affect the noise of the render anyways.
+    # This fixes issue #530
+    new_mat.cycles.sample_as_light = False
     nodes = new_mat.node_tree.nodes
     links = new_mat.node_tree.links
     emission_node = nodes.new(type='ShaderNodeEmission')


### PR DESCRIPTION
fix bug in blender, if there are too many objects in a scene by turning off the sample_as_light option for the materials, removing the multiple importance sampling for them.

This bug fix was provided by: @jascase901