### PR TITLE
fix(vhacd): Sets cmake release mode to vhacd build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/source/*rst
 docs/source/images/
 docs/source/examples/
 docs/source/*md
+blenderproc_resources/

--- a/blenderproc/external/vhacd/build_linux.sh
+++ b/blenderproc/external/vhacd/build_linux.sh
@@ -2,5 +2,5 @@
 
 cd $1
 cd app/
-cmake CMakeLists.txt
+cmake CmakeLists.txt -DCMAKE_BUILD_TYPE=Release
 cmake --build .


### PR DESCRIPTION
Default cmake mode seemed to be Debug. After setting it to Release, vhacd is fast again.

Fixes: #621 