### PR TITLE
feat(loader): Switches to new (experimental) obj loader

### DIFF
--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -34,7 +34,7 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
             previously_selected_objects = bpy.context.selected_objects
             if filepath.endswith('.obj'):
                 # load an .obj file:
-                bpy.ops.import_scene.obj(filepath=filepath, **kwargs)
+                bpy.ops.wm.obj_import(filepath=filepath, **kwargs)
             elif filepath.endswith('.ply'):
                 # load a .ply mesh
                 bpy.ops.import_mesh.ply(filepath=filepath, **kwargs)


### PR DESCRIPTION
With blender 3.2 came a new experimental obj loader (which is not used per default). The new loader seems to be about 10x faster!