### PR TITLE
fix(debug): Fixes running script in debug multiple times

### DIFF
--- a/blenderproc/__init__.py
+++ b/blenderproc/__init__.py
@@ -12,7 +12,8 @@ if "INSIDE_OF_THE_INTERNAL_BLENDER_PYTHON_ENVIRONMENT" in os.environ:
     # that we do not want to import inside the blenderproc env
     sys.path.remove(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
     # Also clean the python path as this might disturb the pip installs
-    del os.environ["PYTHONPATH"]
+    if "PYTHONPATH" in os.environ:
+        del os.environ["PYTHONPATH"]
     from .python.utility.SetupUtility import SetupUtility
     SetupUtility.setup([])
     from .api import loader


### PR DESCRIPTION
In debug mode, our `__init__.py` script is run each time the script is run. After #629 this leads to an error as the env var has already been deleted and does not exist anymore.