### PR TITLE
Iss 636 parent cleanup

### DIFF
--- a/blenderproc/python/loader/BlendLoader.py
+++ b/blenderproc/python/loader/BlendLoader.py
@@ -4,9 +4,7 @@ from typing import List, Union, Optional
 import bpy
 
 from blenderproc.python.utility.BlenderUtility import collect_all_orphan_datablocks
-from blenderproc.python.types.EntityUtility import Entity
-from blenderproc.python.types.LightUtility import Light
-from blenderproc.python.types.MeshObjectUtility import MeshObject
+from blenderproc.python.types.EntityUtility import Entity, convert_to_entity_subclass
 from blenderproc.python.utility.Utility import resolve_path
 
 
@@ -65,12 +63,7 @@ def load_blend(path: str, obj_types: Optional[Union[List[str], str]] = None, nam
                 if obj.type.lower() in obj_types:
                     # Link objects to the scene
                     bpy.context.collection.objects.link(obj)
-                    if obj.type == 'MESH':
-                        loaded_objects.append(MeshObject(obj))
-                    elif obj.type == 'LIGHT':
-                        loaded_objects.append(Light(blender_obj=obj))
-                    else:
-                        loaded_objects.append(Entity(obj))
+                    loaded_objects.append(convert_to_entity_subclass(obj))
 
                     # If a camera was imported
                     if obj.type == 'CAMERA':

--- a/blenderproc/python/types/EntityUtility.py
+++ b/blenderproc/python/types/EntityUtility.py
@@ -116,12 +116,25 @@ class Entity(Struct):
         """ Deselects the entity. """
         self.blender_obj.select_set(False)
 
-    def set_parent(self, parent: "Entity"):
-        """ Sets the parent of entity.
+    def clear_parent(self):
+        """ Removes the object's parent and moves the object into the root level of the scene graph. """
+        # Remember original object pose
+        obj_pose = self.get_local2world_mat()
+        self.blender_obj.parent = None
+        # Make sure the object pose stays the same
+        self.set_local2world_mat(obj_pose)
 
-        :param parent: The parent entity to set.
+    def set_parent(self, new_parent: "Entity"):
+        """ Sets the parent of this object.
+
+        :param new_parent: The parent entity to set.
         """
-        self.blender_obj.parent = parent.blender_obj
+        # If the object has already a parent object, remove it first.
+        if self.blender_obj.parent is not None:
+            self.clear_parent()
+        self.blender_obj.parent = new_parent.blender_obj
+        # Make sure the object pose stays the same => add inverse of new parent's pose to transformation chain
+        self.blender_obj.matrix_parent_inverse = Matrix(new_parent.get_local2world_mat()).inverted()
 
     def get_parent(self) -> Optional["Entity"]:
         """ Returns the parent of the entity.

--- a/blenderproc/python/types/LightUtility.py
+++ b/blenderproc/python/types/LightUtility.py
@@ -9,7 +9,7 @@ import numpy as np
 
 
 class Light(Entity):
-    def __init__(self, type: str = "POINT", name: str = "light", blender_obj: bpy.types.Light = None):
+    def __init__(self, type: str = "POINT", name: str = "light", blender_obj: bpy.types.Object = None):
         """
         Constructs a new light if no blender_obj is given, else the params type and name are used to construct a new
         light.

--- a/blenderproc/python/types/LightUtility.py
+++ b/blenderproc/python/types/LightUtility.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 
 import bpy
 
@@ -9,7 +9,7 @@ import numpy as np
 
 
 class Light(Entity):
-    def __init__(self, type: str = "POINT", name: str = "light", blender_obj: bpy.types.Object = None):
+    def __init__(self, type: str = "POINT", name: str = "light", blender_obj: Optional[bpy.types.Object] = None):
         """
         Constructs a new light if no blender_obj is given, else the params type and name are used to construct a new
         light.

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -72,7 +72,7 @@ class MeshObject(Entity):
         # add the new one
         self.add_material(material)
 
-    def duplicate(self, duplicate_children = True) -> "MeshObject":
+    def duplicate(self, duplicate_children: bool = True) -> "MeshObject":
         """ Duplicates the object.
 
         :param duplicate_children: If True, also all children objects are recursively duplicated.

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -72,15 +72,24 @@ class MeshObject(Entity):
         # add the new one
         self.add_material(material)
 
-    def duplicate(self) -> "MeshObject":
+    def duplicate(self, duplicate_children = True) -> "MeshObject":
         """ Duplicates the object.
 
+        :param duplicate_children: If True, also all children objects are recursively duplicated.
         :return: A new mesh object, which is a duplicate of this object.
         """
         new_entity = self.blender_obj.copy()
         new_entity.data = self.blender_obj.data.copy()
         bpy.context.collection.objects.link(new_entity)
-        return MeshObject(new_entity)
+
+        duplicate_obj = MeshObject(new_entity)
+
+        if duplicate_children:
+            for child in self.get_children():
+                duplicate_child = child.duplicate(duplicate_children=duplicate_children)
+                duplicate_child.set_parent(duplicate_obj)
+
+        return duplicate_obj
 
     def get_mesh(self) -> bpy.types.Mesh:
         """ Returns the blender mesh of the object.
@@ -260,6 +269,13 @@ class MeshObject(Entity):
         :return: The parent object, None if it has no parent.
         """
         return MeshObject(self.blender_obj.parent) if self.blender_obj.parent is not None else None
+
+    def get_children(self) -> List["MeshObject"]:
+        """ Returns the children objects.
+
+        :return: A list of all children objects.
+        """
+        return convert_to_meshes(self.blender_obj.children)
 
     def disable_rigidbody(self):
         """ Disables the rigidbody element of the object """

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -255,20 +255,6 @@ class MeshObject(Entity):
         """
         self.blender_obj.hide_render = hide_object
 
-    def get_parent(self) -> Optional[Entity]:
-        """ Returns the parent object.
-
-        :return: The parent object, None if it has no parent.
-        """
-        return MeshObject(self.blender_obj.parent) if self.blender_obj.parent is not None else None
-
-    def get_children(self) -> List["MeshObject"]:
-        """ Returns the children objects.
-
-        :return: A list of all children objects.
-        """
-        return convert_to_meshes(self.blender_obj.children)
-
     def disable_rigidbody(self):
         """ Disables the rigidbody element of the object """
         if self.has_rigidbody_enabled():

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -255,14 +255,6 @@ class MeshObject(Entity):
         """
         self.blender_obj.hide_render = hide_object
 
-    def set_parent(self, new_parent: Entity):
-        """ Sets the parent of this object.
-
-        :param new_parent: The new parent object.
-        """
-        self.blender_obj.parent = new_parent.blender_obj
-        self.blender_obj.matrix_parent_inverse = Matrix(new_parent.get_local2world_mat()).inverted()
-
     def get_parent(self) -> Optional[Entity]:
         """ Returns the parent object.
 

--- a/tests/testEntity.py
+++ b/tests/testEntity.py
@@ -1,0 +1,76 @@
+import blenderproc as bproc
+
+import unittest
+
+from blenderproc.python.tests.SilentMode import SilentMode
+from blenderproc.python.types.EntityUtility import convert_to_entity_subclass, Entity
+from blenderproc.python.types.LightUtility import Light
+from blenderproc.python.types.MeshObjectUtility import MeshObject
+
+
+class UnitTestCheckUtility(unittest.TestCase):
+
+    def test_convert_to_entity_subclass(self):
+        """ Test if the blender_data objects are still valid after an undo execution is done.
+        """
+        bproc.init()
+        cube = convert_to_entity_subclass(bproc.object.create_primitive("CUBE").blender_obj)
+        empty = convert_to_entity_subclass(bproc.object.create_empty("empty_test").blender_obj)
+        light = convert_to_entity_subclass(bproc.types.Light().blender_obj)
+
+        self.assertEqual(type(cube), MeshObject)
+        self.assertEqual(type(empty), Entity)
+        self.assertEqual(type(light), Light)
+
+    def test_scene_graph_hierarchy_changes(self):
+        bproc.init()
+
+        root = bproc.object.create_primitive("CUBE")
+        root.set_location([1, 0, 0])
+
+        # 1. Add child to root
+        child = bproc.object.create_empty("empty")
+        child.set_location([2, 0, 0])
+        child.set_parent(root)
+        print(child.get_location())
+
+        self.assertEqual(child.get_parent(), root)
+        self.assertEqual(type(child.get_parent()), MeshObject)
+        self.assertTrue((child.get_local2world_mat()[:3, 3] == [2, 0, 0]).all())
+        self.assertEqual(root.get_children(), [child])
+
+        # 2. Move root
+        root.set_location([2, 0, 0])
+        self.assertTrue((child.get_local2world_mat()[:3, 3] == [3, 0, 0]).all())
+
+        # 2. Add grandchild to child
+        grandchild = bproc.types.Light()
+        grandchild.set_location([4, 0, 0])
+        grandchild.set_parent(child)
+
+        self.assertEqual(grandchild.get_parent(), child)
+        self.assertEqual(type(grandchild.get_parent()), Entity)
+        self.assertTrue((grandchild.get_local2world_mat()[:3, 3] == [4, 0, 0]).all())
+        self.assertEqual(child.get_children(), [grandchild])
+
+        # 3. Clear parent of child
+        child.clear_parent()
+
+        # Check child
+        self.assertEqual(child.get_parent(), None)
+        self.assertTrue((child.get_local2world_mat()[:3, 3] == [3, 0, 0]).all())
+        self.assertEqual(root.get_children(), [])
+        # Check grandchild
+        self.assertEqual(grandchild.get_parent(), child)
+        self.assertEqual(type(grandchild.get_parent()), Entity)
+        self.assertTrue((grandchild.get_local2world_mat()[:3, 3] == [4, 0, 0]).all())
+        self.assertEqual(child.get_children(), [grandchild])
+
+        # 4. Make grandchild a child of root
+        grandchild.set_parent(root)
+
+        self.assertEqual(grandchild.get_parent(), root)
+        self.assertEqual(type(grandchild.get_parent()), MeshObject)
+        self.assertTrue((grandchild.get_local2world_mat()[:3, 3] == [4, 0, 0]).all())
+        self.assertEqual(root.get_children(), [grandchild])
+        self.assertEqual(child.get_children(), [])


### PR DESCRIPTION
**Merge first: #633**  

* Puts all children / parent methods into the entity class
* get_children() and get_parent() now use `convert_to_entity_subclass` to return the blender objects wrapped into the correct class
* Adds tests

Fixes #636 