### PR TITLE
Refactors bproc.init function

### DIFF
--- a/blenderproc/__init__.py
+++ b/blenderproc/__init__.py
@@ -20,7 +20,7 @@ if "INSIDE_OF_THE_INTERNAL_BLENDER_PYTHON_ENVIRONMENT" in os.environ:
     from .api import utility
     from .api import sampler
     from .api import math
-    from .python.utility.Initializer import init, cleanup
+    from .python.utility.Initializer import init, clean_up
     from .api import postprocessing
     from .api import writer
     from .api import material

--- a/blenderproc/__init__.py
+++ b/blenderproc/__init__.py
@@ -20,7 +20,7 @@ if "INSIDE_OF_THE_INTERNAL_BLENDER_PYTHON_ENVIRONMENT" in os.environ:
     from .api import utility
     from .api import sampler
     from .api import math
-    from .python.utility.Initializer import init
+    from .python.utility.Initializer import init, cleanup
     from .api import postprocessing
     from .api import writer
     from .api import material

--- a/blenderproc/api/renderer/__init__.py
+++ b/blenderproc/api/renderer/__init__.py
@@ -2,7 +2,7 @@
 from blenderproc.python.renderer.RendererUtility import set_denoiser, set_light_bounces, \
     set_cpu_threads, toggle_stereo, set_simplify_subdivision_render, set_noise_threshold, \
     set_max_amount_of_samples, enable_distance_output, enable_depth_output, enable_normals_output, enable_diffuse_color_output,\
-    map_file_format_to_file_ending, render, set_output_format, enable_motion_blur, set_world_background
+    map_file_format_to_file_ending, render, set_output_format, enable_motion_blur, set_world_background, set_render_devices, enable_experimental_features
 from blenderproc.python.renderer.SegMapRendererUtility import render_segmap
 from blenderproc.python.renderer.FlowRendererUtility import render_optical_flow
 from blenderproc.python.renderer.NOCSRendererUtility import render_nocs

--- a/blenderproc/python/modules/main/InitializerModule.py
+++ b/blenderproc/python/modules/main/InitializerModule.py
@@ -52,7 +52,7 @@ class InitializerModule(Module):
         compute_device = self.config.get_string("compute_device", "GPU")
         compute_device_type = self.config.get_string("compute_device_type", None)
         use_experimental_features = self.config.get_bool("use_experimental_features", False)
-        init(horizon_color, compute_device, compute_device_type, use_experimental_features, clean_up_scene=False)
+        init(clean_up_scene=False)
         RendererUtility.set_world_background(horizon_color)
         RendererUtility.set_render_devices(compute_device == "CPU", compute_device_type)
         if use_experimental_features:

--- a/blenderproc/python/modules/main/InitializerModule.py
+++ b/blenderproc/python/modules/main/InitializerModule.py
@@ -1,6 +1,7 @@
 from blenderproc.python.modules.main.GlobalStorage import GlobalStorage
 from blenderproc.python.modules.main.Module import Module
 from blenderproc.python.modules.utility.Config import Config
+from blenderproc.python.renderer import RendererUtility
 from blenderproc.python.utility.Initializer import init, cleanup
 
 
@@ -52,3 +53,7 @@ class InitializerModule(Module):
         compute_device_type = self.config.get_string("compute_device_type", None)
         use_experimental_features = self.config.get_bool("use_experimental_features", False)
         init(horizon_color, compute_device, compute_device_type, use_experimental_features, clean_up_scene=False)
+        RendererUtility.set_world_background(horizon_color)
+        RendererUtility.set_render_devices(compute_device == "CPU", compute_device_type)
+        if use_experimental_features:
+          RendererUtility.enable_experimental_features()

--- a/blenderproc/python/modules/main/InitializerModule.py
+++ b/blenderproc/python/modules/main/InitializerModule.py
@@ -2,7 +2,7 @@ from blenderproc.python.modules.main.GlobalStorage import GlobalStorage
 from blenderproc.python.modules.main.Module import Module
 from blenderproc.python.modules.utility.Config import Config
 from blenderproc.python.renderer import RendererUtility
-from blenderproc.python.utility.Initializer import init, cleanup
+from blenderproc.python.utility.Initializer import init, clean_up
 
 
 class InitializerModule(Module):
@@ -38,7 +38,7 @@ class InitializerModule(Module):
         Module.__init__(self, config)
 
         # Clean up example scene or scene created by last run when debugging pipeline inside blender
-        cleanup()
+        clean_up()
 
         # setting up the GlobalStorage
         global_config = Config(self.config.get_raw_dict("global", {}))

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -639,8 +639,8 @@ def set_render_devices(use_only_cpu: bool = False, desired_gpu_device_type: Unio
         desired_gpu_device_type = [desired_gpu_device_type]
 
     # Make sure desired_gpu_device_type is a list
-    if desired_gpu_ids is not None and not isinstance(desired_gpu_device_type, list):
-        desired_gpu_device_type = [desired_gpu_device_type]
+    if desired_gpu_ids is not None and not isinstance(desired_gpu_ids, list):
+        desired_gpu_ids = [desired_gpu_ids]
 
     # Decide between gpu and cpu rendering
     if not desired_gpu_device_type or use_only_cpu:

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -620,6 +620,9 @@ def set_render_devices(use_only_cpu: bool = False, desired_gpu_device_type: Unio
                                     Possible choices are ["OPTIX", "CUDA", "METAL", "HIP"]. Default is ["OPTIX", "CUDA", "HIP"] on linux/windows and ["METAL"] on supported mac devices.
     :param desired_gpu_ids: One or multiple GPU ids to specifically use. If none is given, all suitable GPUs are used.
     """
+    # Mark beginning of selection to avoid confusion when calling set_render_devices multiple times:
+    print("Selecting render devices...")
+
     if desired_gpu_device_type is None:
         # If no gpu types are specified, use the default types based on the OS
         if platform == "darwin":

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -617,10 +617,11 @@ def set_render_devices(use_only_cpu: bool = False, desired_gpu_device_type: Unio
 
     :param use_only_cpu: If True, only the cpu is used for rendering.
     :param desired_gpu_device_type: One or multiple GPU device types to consider. If multiple are given, the first available is used. 
-                                    Possible choices are ["OPTIX", "CUDA", "METAL", "HIP"]. Default is ["OPTIX", "CUDA", "HIP"] and ["METAL"] on supported mac devices.
+                                    Possible choices are ["OPTIX", "CUDA", "METAL", "HIP"]. Default is ["OPTIX", "CUDA", "HIP"] on linux/windows and ["METAL"] on supported mac devices.
     :param desired_gpu_ids: One or multiple GPU ids to specifically use. If none is given, all suitable GPUs are used.
     """
     if desired_gpu_device_type is None:
+        # If no gpu types are specified, use the default types based on the OS
         if platform == "darwin":
             import platform as platform_locally
             mac_version = platform_locally.mac_ver()[0]
@@ -635,6 +636,10 @@ def set_render_devices(use_only_cpu: bool = False, desired_gpu_device_type: Unio
             desired_gpu_device_type = ["OPTIX", "CUDA", "HIP"]
     elif not isinstance(desired_gpu_device_type, list):
         # Make sure its a list
+        desired_gpu_device_type = [desired_gpu_device_type]
+
+    # Make sure desired_gpu_device_type is a list
+    if desired_gpu_ids is not None and not isinstance(desired_gpu_device_type, list):
         desired_gpu_device_type = [desired_gpu_device_type]
 
     # Decide between gpu and cpu rendering

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -669,17 +669,17 @@ def set_render_devices(use_only_cpu: bool = False, desired_gpu_device_type: Unio
                 for i, device in enumerate(devices):
                     # Only use gpus with specified ids
                     if desired_gpu_ids is None or i in desired_gpu_ids:
-                        print('Device {} of type {} found and used.'.format(device.name, device.type))
+                        print(f"Device {device.name} of type {device.type} found and used.")
                         device.use = True        
                         found = True
                     else:
                         device.use = False
 
                 if not found:
-                    raise Exception("The specified gpu ids lead to no selected gpu at all. Valid gpu ids are " + str(list(range(len(devices)))))
+                    raise RuntimeError(f"The specified gpu ids lead to no selected gpu at all. Valid gpu ids are {list(range(len(devices)))}")
 
                 break
 
         if not found:
-            raise Exception("No GPU could be found with the specified device types: " + str(desired_gpu_device_type))
+            raise RuntimeError(f"No GPU could be found with the specified device types: {desired_gpu_device_type}")
 

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -35,6 +35,7 @@ class DefaultConfig:
     transparency_bounces = 8
     volume_bounces = 0
     antialiasing_distance_max = 10000
+    world_background = [0.05, 0.05, 0.05]
 
     # Setup
     default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", "gitpython==3.1.18", "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3",

--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -14,83 +14,28 @@ import addon_utils
 import blenderproc.python.renderer.RendererUtility as RendererUtility
 
 
-def init(horizon_color: list = [0.05, 0.05, 0.05], compute_device: str = "GPU", compute_device_type: str = None, use_experimental_features: bool = False, clean_up_scene: bool = True):
+def init():
     """ Initializes basic blender settings, the world and the camera.
 
     Also cleans up the whole scene at first.
-
-    :param horizon_color: The color to use for the world background.
-    :param compute_device: The compute device to use for the Cycles Render Engine i.e. CPU or GPU. (default: ``GPU``).
-    :param compute_device_type: The compute device type to use for the Cycles Render Engine i.e. OPTIX or CUDA. Only necessary to specify, if compute device is GPU. If None is given, the available device type is used (OPTIX is preferred).
-    :param use_experimental_features: Set to True, if you want to use the Experimental features of the Cycles Render Engine i.e Adaptive subdivision. (default: ``False``).
-    :param clean_up_scene: Set to False, if you want to keep all scene data.
     """
-    if clean_up_scene:
-        cleanup()
+    cleanup()
 
     # Set language if necessary
     if bpy.context.preferences.view.language != "en_US":
         print("Setting blender language settings to english during this run")
         bpy.context.preferences.view.language = "en_US"
 
-    prefs = bpy.context.preferences.addons['cycles'].preferences
     # Use cycles
     bpy.context.scene.render.engine = 'CYCLES'
 
-    if platform == "darwin":
-        import platform as platform_locally
-        mac_version = platform_locally.mac_ver()[0]
-        mac_version_numbers = [int(ele) for ele in mac_version.split(".")]
-        if (mac_version_numbers[0] == 12 and mac_version_numbers[1] >= 3) or mac_version_numbers[0] > 12:
-            bpy.context.scene.cycles.device = "GPU"
-            preferences = bpy.context.preferences.addons['cycles'].preferences
-            for device_type in preferences.get_device_types(bpy.context):
-                preferences.get_devices_for_type(device_type[0])
-            gpu_type = "METAL"  # only available type on mac os
-            for device in preferences.devices:
-                if device.type == gpu_type and (compute_device_type is None or compute_device_type == gpu_type):
-                    bpy.context.preferences.addons['cycles'].preferences.compute_device_type = gpu_type
-                    print('Device {} of type {} found and used.'.format(device.name, device.type))
-                    break
-            # make sure that all visible GPUs are used
-            for device in prefs.devices:
-                device.use = True
-        else:
-            # there is no gpu support on mac os below 12.3, if cpu is specified as compute device,
-            # then we use the cpu with maximum power
-            bpy.context.scene.cycles.device = "CPU"
-            bpy.context.scene.render.threads = multiprocessing.cpu_count()
-    elif compute_device == "CPU":
-        bpy.context.scene.cycles.device = "CPU"
-        bpy.context.scene.render.threads = multiprocessing.cpu_count()
-    else:
-        bpy.context.scene.cycles.device = "GPU"
-        preferences = bpy.context.preferences.addons['cycles'].preferences
-        for device_type in preferences.get_device_types(bpy.context):
-            preferences.get_devices_for_type(device_type[0])
-        for gpu_type in ["OPTIX", "CUDA"]:
-            found = False
-            for device in preferences.devices:
-                if device.type == gpu_type and (compute_device_type is None or compute_device_type == gpu_type):
-                    bpy.context.preferences.addons['cycles'].preferences.compute_device_type = gpu_type
-                    print('Device {} of type {} found and used.'.format(device.name, device.type))
-                    found = True
-                    break
-            if found:
-                break
-        # make sure that all visible GPUs are used
-        for device in prefs.devices:
-            device.use = True
-
-    # Set the Experimental features on/off
-    if use_experimental_features:
-        bpy.context.scene.cycles.feature_set = 'EXPERIMENTAL'
+    # Set default render devices
+    RendererUtility.set_render_devices()
 
     # setting the frame end, will be changed by the camera loader modules
     bpy.context.scene.frame_end = 0
 
-    # Sets background color
-    RendererUtility.set_world_background(horizon_color)
+    # Sets world default category id
     world = bpy.data.worlds['World']
     world["category_id"] = 0
 
@@ -139,6 +84,7 @@ class Initializer:
 
         # Init renderer
         RendererUtility._render_init()
+        RendererUtility.set_world_background(DefaultConfig.world_background)
         RendererUtility.set_max_amount_of_samples(DefaultConfig.samples)
         RendererUtility.set_noise_threshold(DefaultConfig.sampling_noise_threshold)
 

--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -1,9 +1,9 @@
 import os
 import random
 from numpy import random as np_random
-from blenderproc.python.modules.main.GlobalStorage import GlobalStorage
 import bpy
 
+from blenderproc.python.modules.main.GlobalStorage import GlobalStorage
 from blenderproc.python.utility.Utility import reset_keyframes
 import blenderproc.python.camera.CameraUtility as CameraUtility
 from blenderproc.python.utility.DefaultConfig import DefaultConfig
@@ -14,16 +14,16 @@ def init(clean_up_scene: bool = True):
     """ Initializes BlenderProc.
 
     Cleans up the whole scene at first and then initializes basic blender settings, the world, the renderer and the camera.
-    This method should only be called once in the beginning. If you want to cleanup the scene afterwards, use bproc.cleanup()
+    This method should only be called once in the beginning. If you want to clean up the scene afterwards, use bproc.clean_up()
 
     :param clean_up_scene: Set to False, if you want to keep all scene data.
     """
     # Check if init has already been run
     if GlobalStorage.is_in_storage("bproc_init_complete") and GlobalStorage.get("bproc_init_complete"):
-        raise Exception("BlenderProc has already been initialized via bproc.init(), this should not be done twice. If you want to cleanup the scene, use bproc.cleanup().")
+        raise RuntimeError("BlenderProc has already been initialized via bproc.init(), this should not be done twice. If you want to clean up the scene, use bproc.clean_up().")
 
     if clean_up_scene:
-        cleanup(cleanup_camera=True)
+        clean_up(clean_up_camera=True)
 
     # Set language if necessary
     if bpy.context.preferences.view.language != "en_US":
@@ -52,20 +52,20 @@ def init(clean_up_scene: bool = True):
     # Remember init was completed
     GlobalStorage.add("bproc_init_complete", True)
 
-def cleanup(cleanup_camera: bool = False):
+def clean_up(clean_up_camera: bool = False):
     """ Resets the scene to its clean state.
     
     This method removes all objects, camera poses and cleans up the world background.
     All (renderer) settings and the UI are kept as they are.
 
-    :param cleanup_camera: If True, also the camera is set back to its clean state.
+    :param clean_up_camera: If True, also the camera is set back to its clean state.
     """
     # Switch to right context
     if bpy.context.object is not None and bpy.context.object.mode != "OBJECT":
         bpy.ops.object.mode_set(mode='OBJECT')
 
     # Clean up
-    Initializer._remove_all_data(cleanup_camera)
+    Initializer._remove_all_data(clean_up_camera)
     Initializer._remove_custom_properties()
 
     # Create new world
@@ -73,7 +73,7 @@ def cleanup(cleanup_camera: bool = False):
     bpy.context.scene.world = new_world
     new_world["category_id"] = 0
 
-    if cleanup_camera:
+    if clean_up_camera:
         # Create the camera
         cam = bpy.data.cameras.new("Camera")
         cam_ob = bpy.data.objects.new("Camera", cam)

--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -10,17 +10,20 @@ from blenderproc.python.utility.DefaultConfig import DefaultConfig
 import blenderproc.python.renderer.RendererUtility as RendererUtility
 
 
-def init():
+def init(clean_up_scene: bool = True):
     """ Initializes BlenderProc.
 
     Cleans up the whole scene at first and then initializes basic blender settings, the world, the renderer and the camera.
     This method should only be called once in the beginning. If you want to cleanup the scene afterwards, use bproc.cleanup()
+
+    :param clean_up_scene: Set to False, if you want to keep all scene data.
     """
     # Check if init has already been run
     if GlobalStorage.is_in_storage("bproc_init_complete") and GlobalStorage.get("bproc_init_complete"):
         raise Exception("BlenderProc has already been initialized via bproc.init(), this should not be done twice. If you want to cleanup the scene, use bproc.cleanup().")
 
-    cleanup(cleanup_camera=True)
+    if clean_up_scene:
+        cleanup(cleanup_camera=True)
 
     # Set language if necessary
     if bpy.context.preferences.view.language != "en_US":


### PR DESCRIPTION
* the complete device selection code moved to the renderer as `bproc.renderer.set_render_devices()` (I think this makes the most sense, as the device is used for rendering)
* `set_render_devices` has three clear parameters: `use_only_cpu`, `desired_gpu_device_type`, `desired_gpu_ids` which should cover all cases (let me know if it doesn't)
* `bproc.cleanup()` can now be used to clean up the scene via the public api, no need to call the init function multiple times
* Calling init multiple times now throws an error
* `horizon_color` and `use_experimental_features` parameters were removed from the init function. They can be set via `bproc.renderer.set_world_background()` and `bproc.renderer.enable_experimental_features()`

Fixes: #631 
Fixes: #585 