### PR TITLE
#736: incorporate location changes to urdf local2world matrix calculations

### DIFF
--- a/blenderproc/python/types/URDFUtility.py
+++ b/blenderproc/python/types/URDFUtility.py
@@ -166,7 +166,7 @@ class URDFObject(Entity):
         matrices = []
         for link in self.links:
             if link.bone is not None:
-                matrices.append(link.bone.matrix)
+                matrices.append(Matrix(self.get_local2world_mat()) @ link.bone.matrix)
         return np.stack(matrices)
 
     def get_all_visual_local2world_mats(self) -> np.array:
@@ -174,21 +174,21 @@ class URDFObject(Entity):
 
         :return: Numpy array of shape (num_bones, 4, 4).
         """
-        return np.stack([link.get_visual_local2world_mats() for link in self.links])
+        return np.stack([link.get_visual_local2world_mats(Matrix(self.get_local2world_mat())) for link in self.links])
 
     def get_all_collision_local2world_mats(self) -> np.array:
         """ Returns all transformations from the world frame to the collision objects.
 
         :return: Numpy array of shape (num_bones, 4, 4).
         """
-        return np.stack([link.get_collision_local2world_mats() for link in self.links])
+        return np.stack([link.get_collision_local2world_mats(Matrix(self.get_local2world_mat())) for link in self.links])
 
     def get_all_inertial_local2world_mats(self) -> np.array:
         """ Returns all transformations from the world frame to the inertial objects.
 
         :return: Numpy array of shape (num_bones, 4, 4).
         """
-        return np.stack([link.get_inertial_local2world_mat() for link in self.links])
+        return np.stack([link.get_inertial_local2world_mat(Matrix(self.get_local2world_mat())) for link in self.links])
 
     def _set_ik_bone_controller(self, bone: bpy.types.PoseBone):
         """ Sets the ik bone controller.


### PR DESCRIPTION
Addresses #736. Adds multiplication of parent pose to a joint's local2world matrix to have location changes correctly calculated.
