### PR TITLE
Suppresses blender debug prints during rendering and physics simulation

### DIFF
--- a/blenderproc/python/renderer/FlowRendererUtility.py
+++ b/blenderproc/python/renderer/FlowRendererUtility.py
@@ -17,7 +17,8 @@ def render_optical_flow(output_dir: str = None, temp_dir: str = None, get_forwar
                         forward_flow_output_file_prefix: str = "forward_flow_",
                         forward_flow_output_key: str = "forward_flow",
                         backward_flow_output_file_prefix: str = "backward_flow_",
-                        backward_flow_output_key: str = "backward_flow", return_data: bool = True) -> \
+                        backward_flow_output_key: str = "backward_flow", return_data: bool = True,
+                        verbose: bool = False) -> \
         Dict[str, Union[np.ndarray, List[np.ndarray]]]:
     """ Renders the optical flow (forward and backward) for all frames.
 
@@ -32,6 +33,7 @@ def render_optical_flow(output_dir: str = None, temp_dir: str = None, get_forwar
     :param backward_flow_output_file_prefix: The file prefix that should be used when writing backward flow to a file.
     :param backward_flow_output_key: The key which should be used for storing backward optical flow values.
     :param return_data: Whether to load and return generated data. Backwards compatibility to config-based pipeline.
+    :param verbose: If True, more details about the rendering process are printed.
     :return: dict of lists of raw renderer outputs. Keys can be 'forward_flow', 'backward_flow'
     """
     if get_forward_flow is False and get_backward_flow is False:
@@ -56,7 +58,8 @@ def render_optical_flow(output_dir: str = None, temp_dir: str = None, get_forwar
         # only need to render once; both fwd and bwd flow will be saved
         temporary_fwd_flow_file_path = os.path.join(temp_dir, 'fwd_flow_')
         temporary_bwd_flow_file_path = os.path.join(temp_dir, 'bwd_flow_')
-        RendererUtility.render(temp_dir, "bwd_flow_", None, load_keys=set())
+        print(f"Rendering {bpy.context.scene.frame_end - bpy.context.scene.frame_start} frames of optical flow...")
+        RendererUtility.render(temp_dir, "bwd_flow_", None, load_keys=set(), verbose=verbose)
 
         # After rendering: convert to optical flow or calculate hsv visualization, if desired
         for frame in range(bpy.context.scene.frame_start, bpy.context.scene.frame_end):

--- a/blenderproc/python/renderer/NOCSRendererUtility.py
+++ b/blenderproc/python/renderer/NOCSRendererUtility.py
@@ -14,7 +14,7 @@ from blenderproc.python.utility.Utility import Utility, UndoAfterExecution
 
 
 def render_nocs(output_dir: Optional[str] = None, file_prefix: str = "nocs_", output_key: str = "nocs",
-                return_data: bool = True) -> Dict[str, List[np.ndarray]]:
+                return_data: bool = True, verbose: bool = False) -> Dict[str, List[np.ndarray]]:
     """ Renders the Normalized Object Coordinate Space (NOCS).
 
     Colors each object based on its local coordinates.
@@ -26,6 +26,7 @@ def render_nocs(output_dir: Optional[str] = None, file_prefix: str = "nocs_", ou
     :param file_prefix: The prefix to use for writing the images.
     :param output_key: The key to use for registering the output.
     :param return_data: Whether to load and return generated data.
+    :param verbose: If True, more details about the rendering process are printed.
     :return: A dict containing one entry "nocs" which points to the list of rendered frames.
     """
     if output_dir is None:
@@ -58,7 +59,7 @@ def render_nocs(output_dir: Optional[str] = None, file_prefix: str = "nocs_", ou
         RendererUtility.set_output_format("OPEN_EXR", 16, enable_transparency=True)
         # Render and ret
         return RendererUtility.render(output_dir, file_prefix, output_key, load_keys={output_key},
-                                      return_data=return_data, keys_with_alpha_channel={output_key})
+                                      return_data=return_data, keys_with_alpha_channel={output_key}, verbose=verbose)
 
 
 class _NOCSRendererUtility:

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -1,7 +1,9 @@
 """Provides functionality to render a color, normal, depth and distance image."""
 
+from contextlib import contextmanager
 import os
-from typing import Union, Dict, List, Set, Optional, Any
+import threading
+from typing import IO, Union, Dict, List, Set, Optional, Any
 import math
 import sys
 import platform
@@ -10,6 +12,9 @@ import time
 import mathutils
 import bpy
 import numpy as np
+from rich.console import Console
+from rich.progress import Progress, TextColumn, BarColumn, TimeRemainingColumn 
+from io import StringIO
 
 from blenderproc.python.camera import CameraUtility
 from blenderproc.python.modules.main.GlobalStorage import GlobalStorage
@@ -524,6 +529,93 @@ def map_file_format_to_file_ending(file_format: str) -> str:
     raise RuntimeError(f"Unknown Image Type {file_format}")
 
 
+def _progress_bar_thread(pipe_out: int, stdout: IO, total_frames: int, num_samples: int):
+    """ The thread rendering the progress bar
+
+    :param pipe_out: The pipe output delivering blenders debug messages.
+    :param stdout: The stdout to which the progress bar should be written.
+    :param total_frames: The number of frames that should be rendered.
+    :param num_samples: The number of samples used to render each frame.
+    """
+    # Define columns for progress bar
+    columns = [
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TimeRemainingColumn(),
+        TextColumn("[progress.description]{task.fields[status]}"),
+    ]
+    # Initializes progress bar using given stdout
+    with Progress(*columns, console=Console(file=stdout), transient=True) as progress:
+        complete_task = progress.add_task("[green]Total", total=total_frames, status="")
+        frame_task = progress.add_task("[yellow]Current frame", total=num_samples, status="")
+
+        # Continuously read blenders debug messages
+        current_line = ""
+        while True:
+            # Read the next character
+            char = os.read(pipe_out, 1).decode()
+            
+            # If its the ending character, stop
+            if not char or "\b" == char:
+                break
+            # If the current line has ended
+            if char == "\n":                
+                # Check if its a line we can use (starts with "Fra:")
+                if current_line.startswith("Fra:"):
+                    # Extract current frame number and set to progress bar
+                    frame_number = int(current_line.split()[0][len("Fra:"):])
+                    progress.update(complete_task, completed=frame_number)
+                    progress.update(complete_task, status=f"Rendering frame {frame_number + 1} of {total_frames}")
+
+                    # Split line into columns
+                    status_columns = [col.strip() for col in current_line.split("|")]
+                    if "Scene, ViewLayer" in status_columns:
+                        # If we are currently at "Scene, ViewLayer", use everything afterwards
+                        status = " | ".join(status_columns[status_columns.index("Scene, ViewLayer") + 1:])
+                        # If we are currently rendering, update the progress 
+                        if status.startswith("Sample"):
+                            progress.update(frame_task, completed=int(status[len("Sample"):].split("/")[0]))
+                    elif "Compositing" in status_columns:
+                        # If we are at "Compositing", use everything afterwards including "Compositing"
+                        status = " | ".join(status_columns[status_columns.index("Compositing"):])
+                        # Set render progress to complete
+                        progress.update(frame_task, completed=num_samples)
+                    else:
+                        # In every other case, use last column
+                        status = status_columns[-1]
+                    # Set status to progress bar
+                    progress.update(frame_task, status=status)
+                # Start with next line
+                current_line = ""
+            else:
+                # Append char to current line
+                current_line += char     
+
+@contextmanager
+def _render_progress_bar(pipe_out: int, pipe_in: int, stdout: IO, total_frames: int, enabled: bool = True):
+    """ Shows a progress bar visualizing the render progress.
+
+    :param pipe_out: The pipe output delivering blenders debug messages.
+    :param pipe_in: The input of the pipe, necessary to send the end character.
+    :param stdout: The stdout to which the progress bar should be written.
+    :param total_frames: The number of frames that should be rendered.
+    :param enabled: If False, no progress bar is shown.
+    """
+    if enabled:
+        thread = threading.Thread(target=_progress_bar_thread, args=(pipe_out, stdout, total_frames, bpy.context.scene.cycles.samples))
+        thread.start()
+        try:
+            yield
+        finally:
+            # Send final character, so the thread knows to stop
+            w = os.fdopen(pipe_in, 'w')
+            w.write("\b")
+            w.close()
+            thread.join()
+    else:
+        yield
+        
+
 def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_key: Optional[str] = "colors",
            load_keys: Optional[Set[str]] = None, return_data: bool = True,
            keys_with_alpha_channel: Optional[Set[str]] = None, verbose: bool = False) -> Dict[str, Union[np.ndarray, List[np.ndarray]]]:
@@ -564,17 +656,22 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
             raise Exception("There are no mesh-objects to render, "
                             "please load an object before invoking the renderer.")
         # Print what is rendered
+        total_frames = bpy.context.scene.frame_end - bpy.context.scene.frame_start
         if load_keys:
             registered_output_keys = [output["key"] for output in Utility.get_registered_outputs()]
             keys_to_render = sorted([key for key in load_keys if key in registered_output_keys])
-            print(f"Rendering {bpy.context.scene.frame_end - bpy.context.scene.frame_start} frames of {', '.join(keys_to_render)}...")
+            print(f"Rendering {total_frames} frames of {', '.join(keys_to_render)}...")
 
         # As frame_end is pointing to the next free frame, decrease it by one, as
         # blender will render all frames in [frame_start, frame_ned]
-        bpy.context.scene.frame_end -= 1     
+        bpy.context.scene.frame_end -= 1    
+           
+        # Define pipe to communicate blenders debug messages to progress bar
+        pipe_out, pipe_in = os.pipe()
         begin = time.time()   
-        with stdout_redirected(enabled=not verbose):
-            bpy.ops.render.render(animation=True, write_still=True)
+        with stdout_redirected(pipe_in, enabled=not verbose) as stdout:
+            with _render_progress_bar(pipe_out, pipe_in, stdout, total_frames, enabled=not verbose):
+                bpy.ops.render.render(animation=True, write_still=True)
         print(f"Finished rendering after {time.time() - begin:.3f} seconds")
         # Revert changes
         bpy.context.scene.frame_end += 1

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -46,4 +46,4 @@ class DefaultConfig:
     default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", "gitpython==3.1.18",
                             "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3", "matplotlib==3.5.1",
                             "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64",
-                            "scikit-learn==1.0.2", "python-dateutil==2.8.2"]
+                            "scikit-learn==1.0.2", "python-dateutil==2.8.2", "rich==12.6.0"]

--- a/blenderproc/python/utility/Utility.py
+++ b/blenderproc/python/utility/Utility.py
@@ -718,7 +718,10 @@ def get_file_descriptor(file_or_fd: Union[int, IO]) -> int:
     :param file_or_fd: Either a file or a file descriptor. If a file descriptor is given, it is returned directly.
     :return: The file descriptor of the given file.
     """
-    fd = getattr(file_or_fd, 'fileno', lambda: file_or_fd)()
+    if hasattr(file_or_fd, 'fileno'):
+        fd = file_or_fd.fileno()
+    else:
+        fd = file_or_fd
     if not isinstance(fd, int):
         raise AttributeError("Expected a file (`.fileno()`) or a file descriptor")
     return fd

--- a/blenderproc/python/utility/Utility.py
+++ b/blenderproc/python/utility/Utility.py
@@ -715,6 +715,7 @@ def fileno(file_or_fd: Union[int, IO]) -> int:
     """ Returns the file descriptor of the given file. 
 
     :param file_or_fd: Either a file or a file descriptor. If a file descriptor is given, it is returned directly.
+    :return: The file descriptor of the given file.
     """
     fd = getattr(file_or_fd, 'fileno', lambda: file_or_fd)()
     if not isinstance(fd, int):

--- a/blenderproc/python/utility/Utility.py
+++ b/blenderproc/python/utility/Utility.py
@@ -711,36 +711,6 @@ class NumpyEncoder(json.JSONEncoder):
             return o.tolist()
         return json.JSONEncoder.default(self, o)
 
-class BlockStdOut:
-    """
-    A content manager for setting the frame correctly.
-    """    
-
-    def __init__(self, enable: bool = True):
-        """ Sets the frame number for its complete block.
-
-        :param frame: The frame number to set. If None is given, nothing is changed.
-        """
-        self._enable = enable
-
-    def __enter__(self):
-        if self._enable:
-            logfile = 'blender_render.log'
-            open(logfile, 'a').close()
-            old = os.dup(1)
-            sys.stdout.flush()
-            os.close(1)
-            os.open(logfile, os.O_WRONLY)
-
-    def __exit__(self, exc_type: Optional[Type[BaseException]],
-                 exc_value: Optional[BaseException],
-                 traceback: Optional[TracebackType]):
-         if self._enable:
-            os.close(1)
-            os.dup(old)
-            os.close(old)
-            sys.stdout.write('\r')
-
 def fileno(file_or_fd: Union[int, IO]) -> int:
     """ Returns the file descriptor of the given file. 
 


### PR DESCRIPTION
The output for the basic example now looks like this:
```
Selecting render devices...
Device GeForce GTX 1070 Ti of type CUDA found and used.
Device Intel Core i5-2500K CPU @ 3.30GHz of type CPU found and used.
Timer 'OBJ_import' took 3.0 ms
Rendering 2 frames of colors, normals...
Finished rendering after 10.776 seconds
Merging data for frame 0 into examples/basics/basic/output/0.hdf5
Merging data for frame 1 into examples/basics/basic/output/1.hdf5
```

Fixes: #732