### PR TITLE
fix(ObjectPoseSampler): for the mode on failure the rotation was not set

### DIFF
--- a/blenderproc/python/object/ObjectPoseSampler.py
+++ b/blenderproc/python/object/ObjectPoseSampler.py
@@ -91,7 +91,7 @@ def sample_poses(objects_to_sample: List[MeshObject], sample_pose_func: Callable
 
             if mode_on_failure == 'initial_pose':
                 obj.set_location(initial_location)
-                obj.get_rotation_euler(initial_rotation)
+                obj.set_rotation_euler(initial_rotation)
 
         sample_results[obj] = (amount_of_tries_done, no_collision)
 


### PR DESCRIPTION
A typo caused the rotation not to be set if the mode on failure was set to `initial_pose` inside the sample pose function

fix #757 

Many thanks to: @andrewyguo 