### PR TITLE
fix(types): fix return type of get_all_cps()

### DIFF
--- a/blenderproc/python/object/ObjectReplacer.py
+++ b/blenderproc/python/object/ObjectReplacer.py
@@ -63,7 +63,7 @@ def replace_objects(objects_to_be_replaced: List[MeshObject], objects_to_replace
 
                 # Copy properties to the newly duplicated object
                 if copy_properties:
-                    for key, value in current_object_to_be_replaced.get_all_cps():
+                    for key, value in current_object_to_be_replaced.get_all_cps().items():
                         duplicate_new_object.set_cp(key, value)
 
                 duplicate_new_object.hide(False)

--- a/blenderproc/python/types/StructUtility.py
+++ b/blenderproc/python/types/StructUtility.py
@@ -101,7 +101,8 @@ class Struct:
 
         :return: A list of key value pairs
         """
-        return self.blender_obj.items()
+        cps = dict([pair for pair in self.blender_obj.items()])
+        return cps
 
     def clear_all_cps(self):
         """ Removes all existing custom properties the struct has. """

--- a/blenderproc/python/types/StructUtility.py
+++ b/blenderproc/python/types/StructUtility.py
@@ -1,6 +1,6 @@
 """ The base class of all things in BlenderProc. """
 
-from typing import Any
+from typing import Any, Dict
 import weakref
 
 import bpy
@@ -96,12 +96,12 @@ class Struct:
         """
         return key in self.blender_obj
 
-    def get_all_cps(self) -> dict[str, Any]:
+    def get_all_cps(self) -> Dict[str, Any]:
         """ Returns all custom properties as key, value pairs.
 
-        :return: A dictionary of custom properties as key, value pairs 
+        :return: A dictionary of custom properties as key, value pairs
         """
-        return dict([pair for pair in self.blender_obj.items()])
+        return dict(self.blender_obj.items())
 
     def clear_all_cps(self):
         """ Removes all existing custom properties the struct has. """

--- a/blenderproc/python/types/StructUtility.py
+++ b/blenderproc/python/types/StructUtility.py
@@ -96,13 +96,12 @@ class Struct:
         """
         return key in self.blender_obj
 
-    def get_all_cps(self) -> list:
+    def get_all_cps(self) -> dict[str, Any]:
         """ Returns all custom properties as key, value pairs.
 
-        :return: A list of key value pairs
+        :return: A dictionary of custom properties as key, value pairs 
         """
-        cps = dict([pair for pair in self.blender_obj.items()])
-        return cps
+        return dict([pair for pair in self.blender_obj.items()])
 
     def clear_all_cps(self):
         """ Removes all existing custom properties the struct has. """

--- a/examples/advanced/coco_annotations/main.py
+++ b/examples/advanced/coco_annotations/main.py
@@ -15,7 +15,7 @@ objs = bproc.loader.load_blend(args.scene)
 
 # Set some category ids for loaded objects
 for j, obj in enumerate(objs):
-    obj.set_cp("category_id", j+1)
+    obj.set_cp("category_id", j + 1)
 
 # define a light and set its location and energy level
 light = bproc.types.Light()


### PR DESCRIPTION
- Addresses issue #760  
- fix the return type of get_all_cps()
- now returns a list of (key, value) pairs instead of IDPropertyGroupViewItems
- Matches documentation: https://dlr-rm.github.io/BlenderProc/blenderproc.python.types.StructUtility.html#blenderproc.python.types.StructUtility.Struct.get_all_cps

