### PR TITLE
fix(examples): Fixes usage of custom properties in bop_object_pose_sampling example

### DIFF
--- a/examples/datasets/bop_object_pose_sampling/main.py
+++ b/examples/datasets/bop_object_pose_sampling/main.py
@@ -42,8 +42,8 @@ bproc.renderer.enable_depth_output(activate_antialiasing=False)
 bproc.renderer.set_max_amount_of_samples(50)
 
 # add segmentation masks (per class and per instance)
-bproc.renderer.enable_segmentation_output(map_by=["category_id", "instance", "name", "cp_bop_dataset_name"],
-                                          default_values={"category_id": 0, "cp_bop_dataset_name": None})
+bproc.renderer.enable_segmentation_output(map_by=["category_id", "instance", "name", "bop_dataset_name"],
+                                          default_values={"category_id": 0, "bop_dataset_name": None})
 
 # Render five different scenes
 for _ in range(5):


### PR DESCRIPTION
After #693 custom properties should not start with `cp_` anymore. Thats why the bop_object_pose_sampling does not produce any coco annotations at the moment