### PR TITLE
fix(#815): Add closing the pipe handles

### DIFF
--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -676,14 +676,14 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
                 bpy.ops.render.render(animation=True, write_still=True)
         
         # Close Pipes to prevent having unclosed file handles
-        #try:
-        #    os.close(pipe_out)
-        #except OSError:
-        #    pass
-        #try:
-        #    os.close(pipe_in)
-        #except OSError:
-        #    pass
+        try:
+            os.close(pipe_out)
+        except OSError:
+            pass
+        try:
+            os.close(pipe_in)
+        except OSError:
+            pass
         
         print(f"Finished rendering after {time.time() - begin:.3f} seconds")
         # Revert changes

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -674,6 +674,17 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
         with stdout_redirected(pipe_in, enabled=not verbose) as stdout:
             with _render_progress_bar(pipe_out, pipe_in, stdout, total_frames, enabled=not verbose):
                 bpy.ops.render.render(animation=True, write_still=True)
+        
+        # Close Pipes to prevent having unclosed file handles
+        #try:
+        #    os.close(pipe_out)
+        #except OSError:
+        #    pass
+        #try:
+        #    os.close(pipe_in)
+        #except OSError:
+        #    pass
+        
         print(f"Finished rendering after {time.time() - begin:.3f} seconds")
         # Revert changes
         bpy.context.scene.frame_end += 1


### PR DESCRIPTION
Fixes #815 

After investigating the issue, I initially expected `stdout_redirected` to be responsible for the file handle leak. As it turns out, this is not the case. Simply closing the pipes after the rendering works.

We have to add a `try .. except` for the closing because `pipe_in` is changed (maybe even closed?) inside the `stdout_redirected`, therefore closing it again does not work.