### PR TITLE
fix(832): Set renderer canvas current canvas

### DIFF
--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -494,7 +494,7 @@ class _BopWriterUtility:
         width = bpy.context.scene.render.resolution_x
         height = bpy.context.scene.render.resolution_y
         ren = renderer.create_renderer(width=width, height=height, renderer_type='vispy', mode='depth')
-
+        ren.set_current()
         for obj in dataset_objects:
             ren.add_object(obj_id=obj.get_cp('category_id'), model_path=obj.get_cp('model_path'))
 
@@ -576,6 +576,7 @@ class _BopWriterUtility:
         ren_width, ren_height = 3 * im_width, 3 * im_height
         ren_cx_offset, ren_cy_offset = im_width, im_height
         ren = renderer.create_renderer(width=ren_width, height=ren_height, renderer_type='vispy', mode='depth')
+        ren.set_current()
         
         for obj in dataset_objects:
             ren.add_object(obj_id=obj.get_cp('category_id'), model_path=obj.get_cp('model_path'))


### PR DESCRIPTION
Since the bop_toolkit vispy renderer inherits from app.canvas it's a canvas object itself. Since the canvas is only initialized when the renderer is initialized, the focus is lost when another renderer instance is created. This can be solved by adding  `ren.set_current()` (see https://vispy.org/api/vispy.app.canvas.html) after the 'creation' (since it's an argument based singleton, it will just return an instance with the same arguments) of the renderer.

This examples, compared to the code shown in #832, solves the issue:
```python
import blenderproc as bproc
from bop_toolkit_lib import inout, misc, visibility, renderer
import numpy as np

while 1:
    width = 128
    height = 720
    print("1. START")
    ren = renderer.create_renderer(width=width, height=height, renderer_type='vispy', mode='depth')
    ren.set_current()
    ren.add_object(obj_id=0, model_path='cybathlon_models/cybathlon_disc.ply')
    depth = ren.render_object(0, np.eye(3), np.array([1,0,0]), 10, 10, 10, 10)['depth']
    print('1. STOP')
    width = 128*3
    height = 720*3
    print("2. START")
    ren = renderer.create_renderer(width=width, height=height, renderer_type='vispy', mode='depth')
    ren.set_current()
    ren.add_object(obj_id=0, model_path='cybathlon_models/cybathlon_disc.ply')
    depth = ren.render_object(0, np.eye(3), np.array([1,0,0]), 10, 10, 10, 10)['depth']
    print('2. STOP')
    width = 128*9
    height = 720*9
    print("3. START")
    ren = renderer.create_renderer(width=width, height=height, renderer_type='vispy', mode='depth')
    ren.set_current()
    ren.add_object(obj_id=0, model_path='cybathlon_models/cybathlon_disc.ply')
    depth = ren.render_object(0, np.eye(3), np.array([1,0,0]), 10, 10, 10, 10)['depth']
    print('3. STOP')

```

Since we use the bop_toolkit renderer at the moment to create the bop gt masks and info, I add `.set_current` where needed.