### PR TITLE
fix(#821): correctly load .stl objects in urdf files

### DIFF
--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -93,7 +93,7 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
         bpy.ops.wm.collada_import(filepath=filepath)
     elif filepath.lower().endswith('.stl'):
         # load a .stl file
-        bpy.ops.import_mesh.stl(filepath=filepath, **kwargs)
+        bpy.ops.wm.stl_import(filepath=filepath, **kwargs)
         # add a default material to stl file
         mat = bpy.data.materials.new(name="stl_material")
         mat.use_nodes = True


### PR DESCRIPTION
Small fix for #821. Uses `bpy.ops.wm.stl_import` instead of `bpy.ops.import_mesh.stl` to match the default parameters listed in https://github.com/DLR-RM/BlenderProc/blob/84ac7dff1351a36f2bde92888590e7cb48e1704b/blenderproc/python/loader/URDFLoader.py#L337