### PR TITLE
Refactored to download in parralel

### DIFF
--- a/blenderproc/scripts/download_haven.py
+++ b/blenderproc/scripts/download_haven.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 import argparse
 from typing import Callable
-
+from progressbar import ProgressBar, Percentage, Bar, ETA, AdaptiveETA
+import concurrent.futures
 import requests
 
 
@@ -36,7 +37,7 @@ def cli():
         if args.types and item_type not in args.types:
             return
 
-        print("Downloading " + output_dir.name + "...")
+        print("Preparing download of\t" + output_dir.name )
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Download listing
@@ -49,16 +50,43 @@ def cli():
             data = {key: value for key, value in data.items() if
                     any(tag_list in args.tags for tag_list in value.get("tags"))}
 
-        for i, item_id in enumerate(data.keys()):
-            # Get item_id and download the item
-            item_output = output_dir / item_id
-            # Skip if it already exists
-            if not item_output.exists() or not any(item_output.iterdir()):
+        # Helper function for filter
+        def item_file_exists(item_id):
+            item_output: Path = output_dir / item_id
+            return not item_output.exists() or not any(item_output.iterdir())
+
+        # Filter to only fetch files not in directory
+        missing_item_ids = list(filter(item_file_exists, map(lambda item_id: item_id, data.keys())))
+
+        # Skip download if no items are missing
+        if not missing_item_ids:
+            print("Skipping download of\t" + output_dir.name + " All files exist")
+            return
+        else:
+            print("Starting download of\t" + output_dir.name )
+
+        # Start threadpool to download
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            # Create a list of futures
+            futures = []
+            for item_id in missing_item_ids:
+                item_output: Path = output_dir / item_id
                 item_output.mkdir(exist_ok=True)
-                print(f"({i}/{len(data)}) {item_id}")
-                item_download_func(item_id, item_output)
-            else:
-                print(f"({i}/{len(data)}) Skipping {item_id} as it already exists")
+                futures.append(executor.submit(item_download_func, item_id, item_output))
+            
+            # Initialize progress bar
+            widgets = [Percentage(),' ', Bar(), ' ', ETA(),' ', AdaptiveETA()]
+            progress = ProgressBar(widgets= widgets, maxval= len(futures))
+            
+            # Execute list of futures
+            for future in progress(concurrent.futures.as_completed(futures)):
+                # Check for any exceptions in the threads
+                try:
+                    future.result()
+                except Exception as exc:
+                    print(f"Thread generated an exception: {exc}")
+
+
 
     def download_texture(item_id: str, output_dir: Path):
         request = requests.get(f"https://api.polyhaven.com/files/{item_id}", timeout=30)

--- a/blenderproc/scripts/download_haven.py
+++ b/blenderproc/scripts/download_haven.py
@@ -19,6 +19,7 @@ def cli():
     parser.add_argument('--format', help="Desired download format for the images.", default="jpg")
     parser.add_argument('--tags', nargs='+', help="Filter by asset tag.", default=None)
     parser.add_argument('--categories', nargs='+', help="Filter by asset category.", default=[])
+    parser.add_argument('--threads', nargs='?', type=int, help="How many threads to use for downloading", default=4)
     parser.add_argument('--types', nargs='+', help="Only download the given types",
                         default=None, choices=["textures", "hdris", "models"])
     args = parser.parse_args()
@@ -66,7 +67,7 @@ def cli():
             print("Starting download of\t" + output_dir.name )
 
         # Start threadpool to download
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers= args.threads) as executor:
             # Create a list of futures
             futures = []
             for item_id in missing_item_ids:


### PR DESCRIPTION
## Refactor "download haven" script to download files in parallel

This pull request is linked to Issue #847 

Changes are as follows: 
1. Use of a thread pool where tasks are executed in parallel. 
2. Added progress bar for downloads instead of writing which file is being downloaded
3. Check if files exists beforehand. Skip download if true. 

Performance test:
- Before change: 15 min 15 s
- After change: 5 min 2 s

Test was made with a 300 Mbit/s internet connection.

