### PR TITLE
Fixed bug where default thread count exeed system thread count for haven download script

### DIFF
--- a/blenderproc/scripts/download_haven.py
+++ b/blenderproc/scripts/download_haven.py
@@ -20,13 +20,13 @@ def cli():
     parser.add_argument('--format', help="Desired download format for the images.", default="jpg")
     parser.add_argument('--tags', nargs='+', help="Filter by asset tag.", default=None)
     parser.add_argument('--categories', nargs='+', help="Filter by asset category.", default=[])
-    parser.add_argument('--workers', nargs='?', type=int, help="How many threads to use for downloading", default=4)
+    parser.add_argument('--threads', nargs='?', type=int, help="How many threads to use for downloading", default=4)
     parser.add_argument('--types', nargs='+', help="Only download the given types",
                         default=None, choices=["textures", "hdris", "models"])
     args = parser.parse_args()
     args_output_dir = Path(args.output_folder)
     
-    args_max_workers = min(args.workers, cpu_count())
+    args_max_workers = min(args.threads, cpu_count())
 
 
     def download_file(url: str, output_path: str):

--- a/blenderproc/scripts/download_haven.py
+++ b/blenderproc/scripts/download_haven.py
@@ -5,6 +5,7 @@ import argparse
 from typing import Callable
 from progressbar import ProgressBar, Percentage, Bar, ETA, AdaptiveETA
 import concurrent.futures
+from multiprocessing import cpu_count
 import requests
 
 
@@ -19,12 +20,14 @@ def cli():
     parser.add_argument('--format', help="Desired download format for the images.", default="jpg")
     parser.add_argument('--tags', nargs='+', help="Filter by asset tag.", default=None)
     parser.add_argument('--categories', nargs='+', help="Filter by asset category.", default=[])
-    parser.add_argument('--threads', nargs='?', type=int, help="How many threads to use for downloading", default=4)
+    parser.add_argument('--workers', nargs='?', type=int, help="How many threads to use for downloading", default=4)
     parser.add_argument('--types', nargs='+', help="Only download the given types",
                         default=None, choices=["textures", "hdris", "models"])
     args = parser.parse_args()
-
     args_output_dir = Path(args.output_folder)
+    
+    args_max_workers = min(args.workers, cpu_count())
+
 
     def download_file(url: str, output_path: str):
         # Download
@@ -67,7 +70,7 @@ def cli():
             print("Starting download of\t" + output_dir.name )
 
         # Start threadpool to download
-        with concurrent.futures.ThreadPoolExecutor(max_workers= args.threads) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers= args_max_workers) as executor:
             # Create a list of futures
             futures = []
             for item_id in missing_item_ids:


### PR DESCRIPTION
I recently made a pull request for refactoring the haven download script to be sequential, it was to address  #847 .

I noticed a potential problem where a system could crash if it has less than 4 threads, but the default is set to 4

Fixed it by creating a check where the `num_workers` is set to the lowest of either the system thread count or the argument thread count. 