### PR TITLE
Adds model_path cp to loaded objects

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,8 @@
 [FORMAT]
 max-line-length=120
-disable=C0103,E0401,R0915,R0913,R0914,R1702,R0912,R0915,R0911,R0903,R0904
+disable=C0103,E0401,R0915,R0913,R0914,R1702,R0912,R0915,R0911,R0903,R0904,W0719,R6102
+enable=consider-using-augmented-assign
+load-plugins=pylint.extensions.code_style
 ignored-modules=urllib,cv2
 # we do not increase the code quality on the old modules anymore:
 ignore-paths=blenderproc/python/modules/.*$,blenderproc/api/.*$

--- a/blenderproc/python/camera/LensDistortionUtility.py
+++ b/blenderproc/python/camera/LensDistortionUtility.py
@@ -114,7 +114,7 @@ def set_lens_distortion(k1: float, k2: float, k3: float = 0.0, p1: float = 0.0, 
     it = 0
     while res[-1] > 0.15:
         r2 = np.square(x) + np.square(y)
-        radial_part = (1 + k1 * r2 + k2 * r2 * r2 + k3 * r2 * r2 * r2)
+        radial_part = 1 + k1 * r2 + k2 * r2 * r2 + k3 * r2 * r2 * r2
         x_ = x * radial_part + 2 * p2 * x * y + p1 * (r2 + 2 * np.square(x))
         y_ = y * radial_part + 2 * p1 * x * y + p2 * (r2 + 2 * np.square(y))
 
@@ -152,8 +152,8 @@ def set_lens_distortion(k1: float, k2: float, k3: float = 0.0, p1: float = 0.0, 
 
     # u and v are now the pixel coordinates on the undistorted image that
     # will distort into the row,column coordinates of the distorted image
-    u = (fx * x + cx)
-    v = (fy * y + cy)
+    u = fx * x + cx
+    v = fy * y + cy
 
     # Stacking this way for the interpolation in the undistorted image array
     mapping_coords = np.vstack([v, u])

--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -101,10 +101,10 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
                                 obj not in previously_selected_objects]
         for obj in selected_objects:
             obj.data.materials.append(mat)
-    
+
     mesh_objects = convert_to_meshes([obj for obj in bpy.context.selected_objects
                                   if obj not in previously_selected_objects])
     # Add model_path cp to all objects
     for obj in mesh_objects:
-        obj.set_cp("model_path", filepath)        
+        obj.set_cp("model_path", filepath)
     return mesh_objects

--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -101,5 +101,10 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
                                 obj not in previously_selected_objects]
         for obj in selected_objects:
             obj.data.materials.append(mat)
-    return convert_to_meshes([obj for obj in bpy.context.selected_objects
+    
+    mesh_objects = convert_to_meshes([obj for obj in bpy.context.selected_objects
                                   if obj not in previously_selected_objects])
+    # Add model_path cp to all objects
+    for obj in mesh_objects:
+        obj.set_cp("model_path", filepath)        
+    return mesh_objects

--- a/blenderproc/python/postprocessing/PostProcessingUtility.py
+++ b/blenderproc/python/postprocessing/PostProcessingUtility.py
@@ -133,7 +133,7 @@ def oil_paint_filter(image: Union[list, np.ndarray], filter_size: int = 5, edges
         if isinstance(image, list) or hasattr(image, "shape") and len(image.shape) > 3:
             return [oil_paint_filter(img, filter_size, edges_only, rgb) for img in image]
 
-        intensity_img = (np.sum(image, axis=2) / 3.0)
+        intensity_img = np.sum(image, axis=2) / 3.0
 
         neighbors = np.array(
             _PostProcessingUtility.get_pixel_neighbors_stacked(image, filter_size, return_list=True))
@@ -205,7 +205,7 @@ def add_kinect_azure_noise(depth: Union[list, np.ndarray], color: Optional[Union
     depth = add_gaussian_shifts(depth, 0.25)
 
     # 0.5mm base noise, 1mm std noise @ 1m, 3.6mm std noise @ 3m
-    depth = depth + (5/10000 + np.maximum((depth-0.5) * 1/1000, 0)) * np.random.normal(size=depth.shape)
+    depth += (5/10000 + np.maximum((depth-0.5) * 1/1000, 0)) * np.random.normal(size=depth.shape)
 
     # Creates the shape of the kernel
     shape = cv2.MORPH_RECT
@@ -507,7 +507,7 @@ class _PostProcessingUtility:
         """
         # The map was scaled to be ranging along the entire 16-bit color depth, and this is the scaling down operation
         # that should remove some noise or deviations
-        image = ((image * 37) / (65536))  # assuming 16 bit color depth
+        image = (image * 37) / (65536)  # assuming 16 bit color depth
         image = image.astype(np.int32)
         b, counts = np.unique(image.flatten(), return_counts=True)
 

--- a/blenderproc/python/postprocessing/StereoGlobalMatching.py
+++ b/blenderproc/python/postprocessing/StereoGlobalMatching.py
@@ -159,7 +159,7 @@ class _StereoGlobalMatching:
             custom_kernel = FULL_KERNEL_5
 
         # Invert
-        valid_pixels = (depth_map > 0.1)
+        valid_pixels = depth_map > 0.1
         depth_map[valid_pixels] = max_depth - depth_map[valid_pixels]
 
         # Dilate
@@ -169,7 +169,7 @@ class _StereoGlobalMatching:
         depth_map = cv2.morphologyEx(depth_map, cv2.MORPH_CLOSE, FULL_KERNEL_5)
 
         # Fill empty spaces with dilated values
-        empty_pixels = (depth_map < 0.1)
+        empty_pixels = depth_map < 0.1
         dilated = cv2.dilate(depth_map, FULL_KERNEL_7)
         depth_map[empty_pixels] = dilated[empty_pixels]
 
@@ -196,12 +196,12 @@ class _StereoGlobalMatching:
             depth_map = cv2.bilateralFilter(depth_map, 5, 1.5, 2.0)
         elif blur_type == 'gaussian':
             # Gaussian blur
-            valid_pixels = (depth_map > 0.1)
+            valid_pixels = depth_map > 0.1
             blurred = cv2.GaussianBlur(depth_map, (5, 5), 0)
             depth_map[valid_pixels] = blurred[valid_pixels]
 
         # Invert
-        valid_pixels = (depth_map > 0.1)
+        valid_pixels = depth_map > 0.1
         depth_map[valid_pixels] = max_depth - depth_map[valid_pixels]
 
         return depth_map

--- a/blenderproc/python/types/LinkUtility.py
+++ b/blenderproc/python/types/LinkUtility.py
@@ -346,13 +346,15 @@ class Link(Entity):
         for obj in self.get_all_objs():
             obj.hide(hide_object=hide_object)
 
-    def get_visual_local2world_mats(self, parent2world_matrix: Matrix) -> Optional[List[Matrix]]:
+    def get_visual_local2world_mats(self, parent2world_matrix: Optional[Matrix] = None) -> Optional[List[Matrix]]:
         """Returns the transformation matrices from world to the visual parts.
 
         :param parent2world_matrix: The transformation from the link's armature to the world frame.
         :return: List of transformation matrices.
         """
         bpy.context.view_layer.update()
+        if parent2world_matrix is None:
+            parent2world_matrix = Matrix(Entity(self.armature).get_local2world_mat())
         bone_mat = Matrix.Identity(4)
         if self.bone is not None:
             bone_mat = self.bone.matrix
@@ -362,13 +364,15 @@ class Link(Entity):
             return [parent2world_matrix @ mat for mat in link2base_mats]
         return None
 
-    def get_collision_local2world_mats(self, parent2world_matrix: Matrix) -> Optional[List[Matrix]]:
+    def get_collision_local2world_mats(self, parent2world_matrix: Optional[Matrix] = None) -> Optional[List[Matrix]]:
         """Returns the transformation matrices from world to the collision parts.
 
         :param parent2world_matrix: The transformation from the link's armature to the world frame.
         :return: List of transformation matrices.
         """
         bpy.context.view_layer.update()
+        if parent2world_matrix is None:
+            parent2world_matrix = Matrix(Entity(self.armature).get_local2world_mat())
         bone_mat = Matrix.Identity(4)
         if self.bone is not None:
             bone_mat = self.bone.matrix
@@ -378,13 +382,15 @@ class Link(Entity):
             return [parent2world_matrix @ mat for mat in link2base_mats]
         return None
 
-    def get_inertial_local2world_mat(self, parent2world_matrix: Matrix) -> Optional[Matrix]:
+    def get_inertial_local2world_mat(self, parent2world_matrix: Optional[Matrix] = None) -> Optional[Matrix]:
         """Returns the transformation matrix from world to the inertial part.
 
         :param parent2world_matrix: The transformation from the link's armature to the world frame.
         :return: The transformation matrix.
         """
         bpy.context.view_layer.update()
+        if parent2world_matrix is None:
+            parent2world_matrix = Matrix(Entity(self.armature).get_local2world_mat())
         bone_mat = Matrix.Identity(4)
         if self.bone is not None:
             bone_mat = self.bone.matrix

--- a/blenderproc/python/utility/SetupUtility.py
+++ b/blenderproc/python/utility/SetupUtility.py
@@ -238,7 +238,7 @@ class SetupUtility:
             if package_version is not None and already_installed:
                 # Check if the correct version is installed
                 # pylint: disable=unsubscriptable-object
-                already_installed = (package_version == SetupUtility.installed_packages[package_name])
+                already_installed = package_version == SetupUtility.installed_packages[package_name]
                 # pylint: enable=unsubscriptable-object
 
             # Only install if it's not already installed (pip would check this itself, but at first downloads the

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -780,7 +780,7 @@ class _BopWriterUtility:
                     if annotation_info is not None:
                         coco_scene_output["annotations"].append(annotation_info)
 
-                    segmentation_id = segmentation_id + 1
+                    segmentation_id += 1
 
             with open(coco_gt_path, 'w', encoding='utf-8') as output_json_file:
                 json.dump(coco_scene_output, output_json_file)

--- a/blenderproc/scripts/download_haven.py
+++ b/blenderproc/scripts/download_haven.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 import argparse
 from typing import Callable
-from progressbar import ProgressBar, Percentage, Bar, ETA, AdaptiveETA
 import concurrent.futures
 from multiprocessing import cpu_count
 import requests
+from progressbar import ProgressBar, Percentage, Bar, ETA, AdaptiveETA
 
 
 def cli():
@@ -25,7 +25,7 @@ def cli():
                         default=None, choices=["textures", "hdris", "models"])
     args = parser.parse_args()
     args_output_dir = Path(args.output_folder)
-    
+
     args_max_workers = min(args.threads, cpu_count())
 
 
@@ -66,8 +66,7 @@ def cli():
         if not missing_item_ids:
             print("Skipping download of\t" + output_dir.name + " All files exist")
             return
-        else:
-            print("Starting download of\t" + output_dir.name )
+        print("Starting download of\t" + output_dir.name )
 
         # Start threadpool to download
         with concurrent.futures.ThreadPoolExecutor(max_workers= args_max_workers) as executor:
@@ -77,11 +76,11 @@ def cli():
                 item_output: Path = output_dir / item_id
                 item_output.mkdir(exist_ok=True)
                 futures.append(executor.submit(item_download_func, item_id, item_output))
-            
+
             # Initialize progress bar
             widgets = [Percentage(),' ', Bar(), ' ', ETA(),' ', AdaptiveETA()]
             progress = ProgressBar(widgets= widgets, maxval= len(futures))
-            
+
             # Execute list of futures
             for future in progress(concurrent.futures.as_completed(futures)):
                 # Check for any exceptions in the threads

--- a/examples/advanced/urdf_loading_and_manipulation/README.md
+++ b/examples/advanced/urdf_loading_and_manipulation/README.md
@@ -114,12 +114,14 @@ meshes. Here we simply print them after the last motion.
 ```python
 bproc.writer.write_bop(os.path.join(args.output_dir, 'bop_data'),
                        target_objects = robot.links,
-                       depths = list(stereo_depth),
+                       depths = data["depth"],
                        colors = data["colors"], 
-                       m2mm = False)
+                       m2mm = False,
+                       calc_mask_info_coco=False)
 ```
 
 The poses of the visual meshes of every robot link can be written using the BOPWriter.
+We disable writing object masks, as this would require setting for each object a `model_path` custom property, which is not yet supported by the URDF loader.
 
 ## Preparing URDF files
 

--- a/examples/advanced/urdf_loading_and_manipulation/main.py
+++ b/examples/advanced/urdf_loading_and_manipulation/main.py
@@ -92,4 +92,5 @@ bproc.writer.write_bop(os.path.join(args.output_dir, 'bop_data'),
                        target_objects = robot.links,
                        depths = data["depth"],
                        colors = data["colors"], 
-                       m2mm = False)
+                       m2mm = False,
+                       calc_mask_info_coco=False)


### PR DESCRIPTION
* All loaded objects get a model_path cp (this should fix the camera_object_pose example)
* In the urdf example, I now disabled `calc_mask_info_coco`, as setting the model_path for links is difficult (one link can have zero or multiple visuals)
* `get_inertial_local2world_mat` of the link class now also works with no parameter given (necessary for bopwriter)
* Fixes some pylint complaints