### PR TITLE
fix: make world after cleanup use nodes as default

### DIFF
--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -77,6 +77,7 @@ def clean_up(clean_up_camera: bool = False):
     # Create new world
     new_world = bpy.data.worlds.new("World")
     bpy.context.scene.world = new_world
+    bpy.context.scene.world.use_nodes = True
     new_world["category_id"] = 0
 
     if clean_up_camera:


### PR DESCRIPTION
`bpy.data.worlds.new()` creates world with `use_nodes` equal to False. This prevents any other function to use world.node_tree.  For example:
   `bproc.world.set_world_background_hdr_img(haven_hdri_path)`
Error:
   nodes = world.node_tree.nodes
   AttributeError: 'NoneType' object has no attribute 'nodes'