### PR TITLE
fix(vis_coco_annotation): changed np.bool to bool

### DIFF
--- a/blenderproc/scripts/vis_coco_annotation.py
+++ b/blenderproc/scripts/vis_coco_annotation.py
@@ -49,7 +49,7 @@ def cli():
         :param rle: Mask in RLE format
         :return: a 2D binary numpy array where '1's represent the object
         """
-        binary_array = np.zeros(np.prod(rle.get('size')), dtype=np.bool)
+        binary_array = np.zeros(np.prod(rle.get('size')), dtype=bool)
         counts = rle.get('counts')
 
         start = 0


### PR DESCRIPTION
numpy.bool is deprecated https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

closes #863 