### PR TITLE
fix(utils): Removes git dependency

### DIFF
--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -43,7 +43,7 @@ class DefaultConfig:
     world_background = [0.05, 0.05, 0.05]
 
     # Setup
-    default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", 
+    default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0",
                             "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3", "matplotlib==3.5.1",
                             "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64",
                             "scikit-learn==1.0.2", "python-dateutil==2.8.2", "rich==12.6.0"]

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -43,7 +43,7 @@ class DefaultConfig:
     world_background = [0.05, 0.05, 0.05]
 
     # Setup
-    default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", "gitpython==3.1.18",
+    default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0", 
                             "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3", "matplotlib==3.5.1",
                             "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64",
                             "scikit-learn==1.0.2", "python-dateutil==2.8.2", "rich==12.6.0"]

--- a/blenderproc/python/utility/Utility.py
+++ b/blenderproc/python/utility/Utility.py
@@ -11,7 +11,6 @@ import time
 import inspect
 import importlib
 import json
-from sys import platform
 from contextlib import contextmanager
 
 import bpy

--- a/blenderproc/python/utility/Utility.py
+++ b/blenderproc/python/utility/Utility.py
@@ -17,10 +17,6 @@ from contextlib import contextmanager
 import bpy
 import numpy as np
 
-if platform != "win32":
-    # importing git doesn't work under windows
-    import git
-
 # pylint: disable=wrong-import-position
 from blenderproc.python.modules.main.GlobalStorage import GlobalStorage
 from blenderproc.python.modules.utility.Config import Config
@@ -177,17 +173,11 @@ class Utility:
 
     @staticmethod
     def get_current_version() -> Optional[str]:
-        """ Gets the git commit hash.
+        """ Gets the current blenderproc version.
 
-        :return: a string, the BlenderProc version, or None if unavailable
+        :return: a string, the BlenderProc version
         """
-        if platform == "win32":
-            return __version__
-        try:
-            repo = git.Repo(search_parent_directories=True)
-        except git.InvalidGitRepositoryError:
-            return __version__
-        return repo.head.object.hexsha
+        return __version__
 
     @staticmethod
     def get_temporary_directory() -> str:


### PR DESCRIPTION
When blenderproc is installed via pip, no git version can be retrieved. Also on windows it is not supported. Therefore, I am removing the dependency, as it is not so useful anyway.

Related: #872