### PR TITLE
Iss830 write bop renderer

### DIFF
--- a/blenderproc/python/types/LinkUtility.py
+++ b/blenderproc/python/types/LinkUtility.py
@@ -5,6 +5,7 @@ from typing import Union, List, Optional, Tuple
 import bpy
 import numpy as np
 from mathutils import Vector, Euler, Matrix
+from trimesh import Trimesh
 
 from blenderproc.python.utility.Utility import KeyFrame
 from blenderproc.python.types.EntityUtility import Entity
@@ -616,5 +617,22 @@ class Link(Entity):
         visual_matrix = M1 @ M_parent_data @ M2 @ M_pose
 
         return visual_matrix.to_quaternion().angle
+
+    def mesh_as_trimesh(self) -> Optional[Trimesh]:
+        """ Returns a trimesh.Trimesh instance of the link's first visual object, if it exists.
+
+        :return: The link's first visual object as trimesh.Trimesh if the link has one or more visuals, else None.
+        """
+        # get mesh data
+        if self.visuals:
+            mesh = self.visuals[0].get_mesh()
+
+            # get vertices and faces
+            verts = np.array([[v.co[0], v.co[1], v.co[2]] for v in mesh.vertices])
+            faces = np.array([[f.vertices[0], f.vertices[1], f.vertices[2]] for f in mesh.polygons])
+
+            return Trimesh(vertices=verts, faces=faces)
+
+        return None
 
 # pylint: enable=no-member

--- a/blenderproc/python/types/LinkUtility.py
+++ b/blenderproc/python/types/LinkUtility.py
@@ -625,13 +625,7 @@ class Link(Entity):
         """
         # get mesh data
         if self.visuals:
-            mesh = self.visuals[0].get_mesh()
-
-            # get vertices and faces
-            verts = np.array([[v.co[0], v.co[1], v.co[2]] for v in mesh.vertices])
-            faces = np.array([[f.vertices[0], f.vertices[1], f.vertices[2]] for f in mesh.polygons])
-
-            return Trimesh(vertices=verts, faces=faces)
+            return self.visuals[0].mesh_as_trimesh()
 
         return None
 

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -524,7 +524,10 @@ class MeshObject(Entity):
             setattr(modifier, key, value)
 
     def mesh_as_trimesh(self) -> Trimesh:
-        """ Returns a trimesh.Trimesh instance of the MeshObject. """
+        """ Returns a trimesh.Trimesh instance of the MeshObject.
+
+        :return: The object as trimesh.Trimesh.
+        """
         # get mesh data
         mesh = self.get_mesh()
 

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -9,6 +9,7 @@ import numpy as np
 import bmesh
 import mathutils
 from mathutils import Vector, Matrix
+from trimesh import Trimesh
 
 from blenderproc.python.types.EntityUtility import Entity
 from blenderproc.python.utility.Utility import Utility, resolve_path
@@ -521,6 +522,17 @@ class MeshObject(Entity):
         modifier = self.blender_obj.modifiers[-1]
         for key, value in kwargs.items():
             setattr(modifier, key, value)
+
+    def mesh_as_trimesh(self) -> Trimesh:
+        """ Returns a trimesh.Trimesh instance of the MeshObject. """
+        # get mesh data
+        mesh = self.get_mesh()
+
+        # get vertices and faces
+        verts = np.array([[v.co[0], v.co[1], v.co[2]] for v in mesh.vertices])
+        faces = np.array([[f.vertices[0], f.vertices[1], f.vertices[2]] for f in mesh.polygons])
+
+        return Trimesh(vertices=verts, faces=faces)
 
 
 def create_from_blender_mesh(blender_mesh: bpy.types.Mesh, object_name: str = None) -> "MeshObject":

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -46,4 +46,5 @@ class DefaultConfig:
     default_pip_packages = ["wheel", "pyyaml==5.1.2", "imageio==2.9.0",
                             "scikit-image==0.19.2", "pypng==0.0.20", "scipy==1.7.3", "matplotlib==3.5.1",
                             "pytz==2021.1", "h5py==3.6.0", "Pillow==8.3.2", "opencv-contrib-python==4.5.5.64",
-                            "scikit-learn==1.0.2", "python-dateutil==2.8.2", "rich==12.6.0"]
+                            "scikit-learn==1.0.2", "python-dateutil==2.8.2", "rich==12.6.0", "trimesh==3.21.5",
+                            "pyrender==0.1.45"]

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -13,6 +13,7 @@ import png
 import cv2
 import bpy
 from mathutils import Matrix
+os.environ['PYOPENGL_PLATFORM'] = 'egl'
 import pyrender
 
 from blenderproc.python.types.MeshObjectUtility import MeshObject, get_all_mesh_objects

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -137,9 +137,12 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
         trimesh_objects = {}
         for obj in dataset_objects:
             trimesh_obj = obj.mesh_as_trimesh()
-            if m2mm:
-                trimesh_obj.apply_scale(scaling=0.001)
-            trimesh_objects[obj.get_cp('category_id')] = pyrender.Mesh.from_trimesh(mesh=trimesh_obj)
+            # we need to create a double-sided material to be able to render non-watertight meshes
+            # the other parameters are defaults, see
+            # https://github.com/mmatl/pyrender/blob/master/pyrender/mesh.py#L216-L223
+            material = pyrender.MetallicRoughnessMaterial(alphaMode='BLEND', baseColorFactor=[0.3, 0.3, 0.3, 1.0],
+                                                          metallicFactor=0.2, roughnessFactor=0.8, doubleSided=True)
+            trimesh_objects[obj.get_cp('category_id')] = pyrender.Mesh.from_trimesh(mesh=trimesh_obj, material=material)
 
         _BopWriterUtility.calc_gt_masks(chunk_dirs=chunk_dirs, starting_frame_id=starting_frame_id,
                                         dataset_objects=trimesh_objects, m2mm=m2mm, delta=delta)

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -136,6 +136,8 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
         # convert all objects to trimesh objects
         trimesh_objects = {}
         for obj in dataset_objects:
+            if obj.get_cp('category_id') in trimesh_objects:
+                continue
             if isinstance(obj, Link):
                 if not obj.visuals:
                     continue

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -136,6 +136,11 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
         # convert all objects to trimesh objects
         trimesh_objects = {}
         for obj in dataset_objects:
+            if isinstance(obj, Link):
+                if not obj.visuals:
+                    continue
+                if len(obj.visuals) > 1:
+                    warnings.warn('BOP Writer only supports saving annotations of one visual mesh per Link')
             trimesh_obj = obj.mesh_as_trimesh()
             # we need to create a double-sided material to be able to render non-watertight meshes
             # the other parameters are defaults, see

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -13,8 +13,6 @@ import png
 import cv2
 import bpy
 from mathutils import Matrix
-os.environ['PYOPENGL_PLATFORM'] = 'egl'
-import pyrender
 
 from blenderproc.python.types.MeshObjectUtility import MeshObject, get_all_mesh_objects
 from blenderproc.python.utility.Utility import Utility, resolve_path
@@ -23,6 +21,11 @@ from blenderproc.python.writer.WriterUtility import _WriterUtility
 from blenderproc.python.types.LinkUtility import Link
 from blenderproc.python.utility.SetupUtility import SetupUtility
 from blenderproc.python.utility.MathUtility import change_target_coordinate_frame_of_transformation_matrix
+
+os.environ['PYOPENGL_PLATFORM'] = 'egl'
+# pylint: disable=wrong-import-position
+import pyrender
+# pylint: enable=wrong-import-position
 
 
 def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None,

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -765,8 +765,6 @@ class _BopWriterUtility:
                 "date_created": datetime.datetime.utcnow().isoformat(' ')
             }
 
-            
-
             # load existing coco annotations
             if dir_counter == 0 and starting_frame_id > 0:
                 misc.log(f"Loading coco annotations from existing chunk dir - {chunk_dir}")

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -153,7 +153,7 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
 
 
 def bop_pose_to_pyrender_coordinate_system(cam_R_m2c: np.ndarray, cam_t_m2c: np.ndarray) -> np.ndarray:
-    """ Converts an object pose in bop format to pyrender coordinate system
+    """ Converts an object pose in bop format to pyrender camera coordinate system
         (https://pyrender.readthedocs.io/en/latest/examples/cameras.html).
 
     :param cam_R_m2c: 3x3 Rotation matrix.

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -120,8 +120,7 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
 
     if calc_mask_info_coco:
         # Set up the bop toolkit
-        SetupUtility.setup_pip(["git+https://github.com/thodan/bop_toolkit", "vispy>=0.6.5",
-                                "PyOpenGL==3.1.0"])
+        SetupUtility.setup_pip(["git+https://github.com/thodan/bop_toolkit", "PyOpenGL==3.1.0"])
 
         # determine which objects to add to the vsipy renderer
         # for numpy>=1.20, np.float is deprecated: https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -162,7 +162,7 @@ def bop_pose_to_pyrender_coordinate_system(cam_R_m2c: np.ndarray, cam_t_m2c: np.
     bop_pose[:3, :3] = cam_R_m2c
     bop_pose[:3, 3] = cam_t_m2c
 
-    # rotate 180° around the x-axis
+    # flip z-axis
     rot = np.eye(4)
     rot[1, 1], rot[2, 2] = -1, -1
     return rot.dot(bop_pose)

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -22,6 +22,7 @@ from blenderproc.python.postprocessing.PostProcessingUtility import dist2depth
 from blenderproc.python.writer.WriterUtility import _WriterUtility
 from blenderproc.python.types.LinkUtility import Link
 from blenderproc.python.utility.SetupUtility import SetupUtility
+from blenderproc.python.utility.MathUtility import change_target_coordinate_frame_of_transformation_matrix
 
 
 def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None,
@@ -161,10 +162,7 @@ def bop_pose_to_pyrender_coordinate_system(cam_R_m2c: np.ndarray, cam_t_m2c: np.
     bop_pose[:3, :3] = cam_R_m2c
     bop_pose[:3, 3] = cam_t_m2c
 
-    # flip z-axis
-    rot = np.eye(4)
-    rot[1, 1], rot[2, 2] = -1, -1
-    return rot.dot(bop_pose)
+    return change_target_coordinate_frame_of_transformation_matrix(bop_pose, ["X", "-Y", "-Z"])
 
 
 class _BopWriterUtility:

--- a/examples/advanced/urdf_loading_and_manipulation/main.py
+++ b/examples/advanced/urdf_loading_and_manipulation/main.py
@@ -93,4 +93,4 @@ bproc.writer.write_bop(os.path.join(args.output_dir, 'bop_data'),
                        depths = data["depth"],
                        colors = data["colors"], 
                        m2mm = False,
-                       calc_mask_info_coco=False)
+                       calc_mask_info_coco=True)


### PR DESCRIPTION
#830 
replaces the vispy renderer in `write_bop()` with pyrenderer. 
directly converts the `MeshObjects` into `trimesh.Trimesh` objects, so we don't need to reload anything here.
whole process itself is pretty fast (should be ~ 1s for 25 frames for a single object)
tested by generating some bop dataset scenes; results look as expected (but there's still a test regarding this right?)