### PR TITLE
Fix dublicate Categories

### DIFF
--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -703,6 +703,10 @@ class _BopWriterUtility:
 
             CATEGORIES = [{'id': obj.get_cp('category_id'), 'name': str(obj.get_cp('category_id')), 'supercategory':
                           dataset_name} for obj in dataset_objects]
+            
+            # Remove all duplicate dicts from list. Ref: https://stackoverflow.com/questions/9427163/remove-duplicate-dict-in-list-in-python
+            CATEGORIES = list({frozenset(item.items()):item for item in CATEGORIES}.values())
+            
             INFO = {
                 "description": dataset_name + '_train',
                 "url": "https://github.com/thodan/bop_toolkit",


### PR DESCRIPTION
Only save unique categories for the scene_gt_json annotations in the BOP writer. 

Response to issue #883

I initially tried to do 
```python
CATEGORIES = list(set(CATEGORIES))  
```
But because `CATEGORIES` is a list of dicts it is not possible, because a dict is not hashable. 

I found an answer on the following stack overflow thread: https://stackoverflow.com/questions/9427163/remove-duplicate-dict-in-list-in-python