### PR TITLE
Fix render progress bar issue with non-ASCII.

### DIFF
--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -552,8 +552,10 @@ def _progress_bar_thread(pipe_out: int, stdout: IO, total_frames: int, num_sampl
         current_line = ""
         while True:
             # Read the next character
-            char = os.read(pipe_out, 1).decode()
-
+            char = os.read(pipe_out, 1)
+            if not char:
+                break
+            char = chr(char[0])
             # If its the ending character, stop
             if not char or "\b" == char:
                 break


### PR DESCRIPTION
UTF-8 has multi-byte characters, and if blender outputs those `.decode()` will raise an Exception.
UTF-8 multi-byte characters will not contain any ASCII bytes. Thus, I changed `.decode` into `chr` to mitigate the issue. The solution will not interfere with `\b` detection.

Sample error script:
https://github.com/liuyulinn/objaverse/blob/master/objaverse1.py

Sample error glb:
[ed3357efe63547e18f5798b273514923.zip](https://github.com/DLR-RM/BlenderProc/files/11619791/ed3357efe63547e18f5798b273514923.zip)

Run the script with:
```bash
blenderproc run objaverse1.py --object-path "ed3357efe63547e18f5798b273514923.glb"
```