### PR TITLE
fix(#914): Allow quad meshes to be converted to trimesh

### DIFF
--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -534,11 +534,12 @@ class MeshObject(Entity):
         # get vertices 
         verts = np.array([[v.co[0], v.co[1], v.co[2]] for v in mesh.vertices])
         
-        # get faces
-        if len(mesh.polygons[0].vertices[:]) == 4:
-            faces = np.array([f.vertices[:] for f in mesh.polygons if len(f.vertices[:]) == 4])
-        else:
-            faces = np.array([[f.vertices[0], f.vertices[1], f.vertices[2]] for f in mesh.polygons])
+        # check if faces are pure tris or quads
+        if not all(len(f.vertices[:]) == len(mesh.polygons[0].vertices[:]) for f in mesh.polygons):
+             raise Exception("The mesh {} must have pure triangular or pure quad faces".format(self.get_name()))
+        
+        # get faces   
+        faces = np.array([f.vertices[:] for f in mesh.polygons if len(f.vertices[:]) in [3, 4]])
 
         return Trimesh(vertices=verts, faces=faces)
     

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -543,8 +543,6 @@ class MeshObject(Entity):
         return Trimesh(vertices=verts, faces=faces)
 
     
-
-
 def create_from_blender_mesh(blender_mesh: bpy.types.Mesh, object_name: str = None) -> "MeshObject":
     """ Creates a new Mesh object using the given blender mesh.
 

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -541,7 +541,6 @@ class MeshObject(Entity):
             faces = np.array([[f.vertices[0], f.vertices[1], f.vertices[2]] for f in mesh.polygons])
 
         return Trimesh(vertices=verts, faces=faces)
-
     
 def create_from_blender_mesh(blender_mesh: bpy.types.Mesh, object_name: str = None) -> "MeshObject":
     """ Creates a new Mesh object using the given blender mesh.

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -531,11 +531,18 @@ class MeshObject(Entity):
         # get mesh data
         mesh = self.get_mesh()
 
-        # get vertices and faces
+        # get vertices 
         verts = np.array([[v.co[0], v.co[1], v.co[2]] for v in mesh.vertices])
-        faces = np.array([[f.vertices[0], f.vertices[1], f.vertices[2]] for f in mesh.polygons])
+        
+        # get faces
+        if len(mesh.polygons[0].vertices[:]) == 4:
+            faces = np.array([f.vertices[:] for f in mesh.polygons if len(f.vertices[:]) == 4])
+        else:
+            faces = np.array([[f.vertices[0], f.vertices[1], f.vertices[2]] for f in mesh.polygons])
 
         return Trimesh(vertices=verts, faces=faces)
+
+    
 
 
 def create_from_blender_mesh(blender_mesh: bpy.types.Mesh, object_name: str = None) -> "MeshObject":


### PR DESCRIPTION
#914 

Some quad meshes are dirty and contain some triangles as well. In that case only include the quad faces.