### PR TITLE
fix: support different combinations of object model scales…

### DIFF
--- a/blenderproc/python/loader/BopLoader.py
+++ b/blenderproc/python/loader/BopLoader.py
@@ -3,6 +3,7 @@
 import os
 from random import choice
 from typing import List, Optional, Tuple
+import warnings
 
 import bpy
 import numpy as np
@@ -16,7 +17,7 @@ from blenderproc.python.loader.ObjectLoader import load_obj
 
 def load_bop_objs(bop_dataset_path: str, model_type: str = "", obj_ids: Optional[List[int]] = None,
                   sample_objects: bool = False, num_of_objs_to_sample: Optional[int] = None,
-                  obj_instances_limit: int = -1, mm2m: bool = False,
+                  obj_instances_limit: int = -1, mm2m: Optional[bool] = None, object_model_unit: str = 'm',
                   move_origin_to_x_y_plane: bool = False) -> List[MeshObject]:
     """ Loads all or a subset of 3D models of any BOP dataset
 
@@ -27,7 +28,9 @@ def load_bop_objs(bop_dataset_path: str, model_type: str = "", obj_ids: Optional
     :param num_of_objs_to_sample: Amount of objects to sample from the specified dataset. If this amount is bigger
                                   than the dataset actually contains, then all objects will be loaded.
     :param obj_instances_limit: Limits the amount of object copies when sampling. Default: -1 (no limit).
-    :param mm2m: Specify whether to convert poses and models to meters.
+    :param mm2m: Specify whether to convert poses and models to meters (deprecated).
+    :param object_model_unit: The unit the object model is in. Object model will be scaled to meters. This does not
+                              affect the annotation units. Available: ['m', 'dm', 'cm', 'mm'].
     :param move_origin_to_x_y_plane: Move center of the object to the lower side of the object, this will not work
                                      when used in combination with pose estimation tasks! This is designed for the
                                      use-case where BOP objects are used as filler objects in the background.
@@ -44,7 +47,12 @@ def load_bop_objs(bop_dataset_path: str, model_type: str = "", obj_ids: Optional
 
     model_p = dataset_params.get_model_params(bop_path, bop_dataset_name, model_type=model_type if model_type else None)
 
-    scale = 0.001 if mm2m else 1
+    assert object_model_unit in ['m', 'dm', 'cm', 'mm'], (f"Invalid object model unit: `{object_model_unit}`. "
+                                                          f"Supported are 'm', 'dm', 'cm', 'mm'")
+    scale = {'m': 1., 'dm': 0.1, 'cm': 0.01, 'mm': 0.001}[object_model_unit]
+    if mm2m is not None:
+        warnings.warn(f"WARNING: `mm2m` is deprecated, please use `object_model_unit='mm'` instead!")
+        scale = 0.001
 
     if obj_ids is None:
         obj_ids = []
@@ -89,7 +97,7 @@ def load_bop_objs(bop_dataset_path: str, model_type: str = "", obj_ids: Optional
 
 def load_bop_scene(bop_dataset_path: str, scene_id: int, model_type: str = "", cam_type: str = "",
                    split: str = "test", source_frame: Optional[List[str]] = None,
-                   mm2m: bool = False) -> List[MeshObject]:
+                   mm2m: Optional[bool] = None, object_model_unit: str = 'm') -> List[MeshObject]:
     """ Replicate a BOP scene from the given dataset: load scene objects, object poses, camera intrinsics and
         extrinsics
 
@@ -107,7 +115,9 @@ def load_bop_scene(bop_dataset_path: str, scene_id: int, model_type: str = "", c
                          blender frame. Has to be a list of three strings. Example: ['X', '-Z', 'Y']:
                          Point (1,2,3) will be transformed to (1, -3, 2). Default: ["X", "-Y", "-Z"],
                          Available: ['X', 'Y', 'Z', '-X', '-Y', '-Z'].
-    :param mm2m: Specify whether to convert poses and models to meters.
+    :param mm2m: Specify whether to convert poses and models to meters (deprecated).
+    :param object_model_unit: The unit the object model is in. Object model will be scaled to meters. This does not
+                              affect the annotation units. Available: ['m', 'dm', 'cm', 'mm'].
     :return: The list of loaded mesh objects.
     """
 
@@ -131,7 +141,12 @@ def load_bop_scene(bop_dataset_path: str, scene_id: int, model_type: str = "", c
     sc_gt = inout.load_scene_gt(split_p['scene_gt_tpath'].format(**{'scene_id': scene_id}))
     sc_camera = inout.load_json(split_p['scene_camera_tpath'].format(**{'scene_id': scene_id}))
 
-    scale = 0.001 if mm2m else 1
+    assert object_model_unit in ['m', 'dm', 'cm', 'mm'], (f"Invalid object model unit: `{object_model_unit}`. "
+                                                          f"Supported are 'm', 'dm', 'cm', 'mm'")
+    scale = {'m': 1., 'dm': 0.1, 'cm': 0.01, 'mm': 0.001}[object_model_unit]
+    if mm2m is not None:
+        warnings.warn("WARNING: `mm2m` is deprecated, please use `object_model_unit='mm'` instead!")
+        scale = 0.001
 
     for i, (cam_id, insts) in enumerate(sc_gt.items()):
         cam_K, cam_H_m2c_ref = _BopLoader.get_ref_cam_extrinsics_intrinsics(sc_camera, cam_id, insts, scale)

--- a/blenderproc/python/loader/BopLoader.py
+++ b/blenderproc/python/loader/BopLoader.py
@@ -350,6 +350,5 @@ class _BopLoader:
         cur_obj.set_cp("model_path", model_path)
         cur_obj.set_cp("is_bop_object", True)
         cur_obj.set_cp("bop_dataset_name", bop_dataset_name)
-        cur_obj.set_cp("scale_factor", scale)
 
         return cur_obj

--- a/blenderproc/python/loader/BopLoader.py
+++ b/blenderproc/python/loader/BopLoader.py
@@ -350,5 +350,6 @@ class _BopLoader:
         cur_obj.set_cp("model_path", model_path)
         cur_obj.set_cp("is_bop_object", True)
         cur_obj.set_cp("bop_dataset_name", bop_dataset_name)
+        cur_obj.set_cp("scale_factor", scale)
 
         return cur_obj

--- a/blenderproc/python/types/EntityUtility.py
+++ b/blenderproc/python/types/EntityUtility.py
@@ -61,12 +61,6 @@ class Entity(Struct):
                       frame number is used.
         """
         self.blender_obj.scale = scale
-        # set the scale factor
-        if not np.all(np.isclose(np.array(scale), scale[0])):
-            print("WARNING: the scale is not the same across all dimensions, writing bop_toolkit annotations with the "
-                  "bop writer will fail!")
-        self.set_cp("scale_factor", scale[0] * self.get_cp("scale_factor")) if self.has_cp("scale_factor") else \
-            self.set_cp("scale_factor", scale[0])
         Utility.insert_keyframe(self.blender_obj, "scale", frame)
 
     def get_location(self, frame: Optional[int] = None) -> np.ndarray:

--- a/blenderproc/python/types/EntityUtility.py
+++ b/blenderproc/python/types/EntityUtility.py
@@ -61,8 +61,12 @@ class Entity(Struct):
                       frame number is used.
         """
         self.blender_obj.scale = scale
-        self.set_cp("scale_factor", scale * self.get_cp("scale_factor")) if self.has_cp("scale_factor") else \
-            self.set_cp("scale_factor", scale)
+        # set the scale factor
+        if not np.all(np.isclose(np.array(scale), scale[0])):
+            print("WARNING: the scale is not the same across all dimensions, writing bop_toolkit annotations with the "
+                  "bop writer will fail!")
+        self.set_cp("scale_factor", scale[0] * self.get_cp("scale_factor")) if self.has_cp("scale_factor") else \
+            self.set_cp("scale_factor", scale[0])
         Utility.insert_keyframe(self.blender_obj, "scale", frame)
 
     def get_location(self, frame: Optional[int] = None) -> np.ndarray:

--- a/blenderproc/python/types/EntityUtility.py
+++ b/blenderproc/python/types/EntityUtility.py
@@ -61,6 +61,8 @@ class Entity(Struct):
                       frame number is used.
         """
         self.blender_obj.scale = scale
+        self.set_cp("scale_factor", scale * self.get_cp("scale_factor")) if self.has_cp("scale_factor") else \
+            self.set_cp("scale_factor", scale)
         Utility.insert_keyframe(self.blender_obj, "scale", frame)
 
     def get_location(self, frame: Optional[int] = None) -> np.ndarray:

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -531,18 +531,21 @@ class MeshObject(Entity):
         # get mesh data
         mesh = self.get_mesh()
 
-        # get vertices 
+        # get vertices
         verts = np.array([[v.co[0], v.co[1], v.co[2]] for v in mesh.vertices])
-        
+
         # check if faces are pure tris or quads
         if not all(len(f.vertices[:]) == len(mesh.polygons[0].vertices[:]) for f in mesh.polygons):
-             raise Exception("The mesh {} must have pure triangular or pure quad faces".format(self.get_name()))
-        
-        # get faces   
+            raise Exception(f"The mesh {self.get_name()} must have pure triangular or pure quad faces")
+
+        # re-scale the vertices since scale operations doesn't apply to the mesh data
+        verts *= self.blender_obj.scale
+
+        # get faces
         faces = np.array([f.vertices[:] for f in mesh.polygons if len(f.vertices[:]) in [3, 4]])
 
         return Trimesh(vertices=verts, faces=faces)
-    
+
 def create_from_blender_mesh(blender_mesh: bpy.types.Mesh, object_name: str = None) -> "MeshObject":
     """ Creates a new Mesh object using the given blender mesh.
 

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -32,8 +32,8 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
               depths: Optional[List[np.ndarray]] = None, colors: Optional[List[np.ndarray]] = None,
               color_file_format: str = "PNG", dataset: str = "", append_to_existing_output: bool = True,
               depth_scale: float = 1.0, jpg_quality: int = 95, save_world2cam: bool = True,
-              ignore_dist_thres: float = 100., annotation_unit: str = 'mm', frames_per_chunk: int = 1000,
-              calc_mask_info_coco: bool = True, delta: float = 0.015):
+              ignore_dist_thres: float = 100., m2mm: Optional[bool] = None, annotation_unit: str = 'mm',
+              frames_per_chunk: int = 1000, calc_mask_info_coco: bool = True, delta: float = 0.015):
     """Write the BOP data
 
     :param output_dir: Path to the output directory.
@@ -52,6 +52,8 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
                            in scene_camera.json
     :param ignore_dist_thres: Distance between camera and object after which object is ignored. Mostly due to
                               failed physics.
+    :param m2mm: Original bop annotations and models are in mm. If true, we convert the gt annotations to mm here. This
+                 is needed if BopLoader option mm2m is used (deprecated).
     :param annotation_unit: The unit in which the annotations are saved. Available: 'm', 'dm', 'cm', 'mm'.
     :param frames_per_chunk: Number of frames saved in each chunk (called scene in BOP)
     :param calc_mask_info_coco: Whether to calculate gt masks, gt info and gt coco annotations.
@@ -119,6 +121,9 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
     assert annotation_unit in ['m', 'dm', 'cm', 'mm'], (f"Invalid annotation unit: `{annotation_unit}`. Supported "
                                                         f"are 'm', 'dm', 'cm', 'mm'")
     annotation_scale = {'m': 1., 'dm': 10., 'cm': 100., 'mm': 1000.}[annotation_unit]
+    if m2mm is not None:
+        warnings.warn("WARNING: `m2mm` is deprecated, please use `annotation_scale='mm'` instead!")
+        annotation_scale = 1000.
     _BopWriterUtility.write_frames(chunks_dir, dataset_objects=dataset_objects, depths=depths, colors=colors,
                                    color_file_format=color_file_format, frames_per_chunk=frames_per_chunk,
                                    annotation_scale=annotation_scale, ignore_dist_thres=ignore_dist_thres,

--- a/examples/advanced/urdf_loading_and_manipulation/README.md
+++ b/examples/advanced/urdf_loading_and_manipulation/README.md
@@ -117,7 +117,7 @@ bproc.writer.write_bop(os.path.join(args.output_dir, 'bop_data'),
                        depths = data["depth"],
                        colors = data["colors"], 
                        m2mm = False,
-                       calc_mask_info_coco=False)
+                       calc_mask_info_coco=True)
 ```
 
 The poses of the visual meshes of every robot link can be written using the BOPWriter.

--- a/examples/advanced/urdf_loading_and_manipulation/main.py
+++ b/examples/advanced/urdf_loading_and_manipulation/main.py
@@ -91,6 +91,5 @@ bproc.writer.write_hdf5(args.output_dir, data)
 bproc.writer.write_bop(os.path.join(args.output_dir, 'bop_data'),
                        target_objects = robot.links,
                        depths = data["depth"],
-                       colors = data["colors"], 
-                       m2mm = False,
+                       colors = data["colors"],
                        calc_mask_info_coco=True)

--- a/examples/basics/camera_object_pose/config.yaml
+++ b/examples/basics/camera_object_pose/config.yaml
@@ -22,7 +22,8 @@
       "config": {
         "path": "<args:0>", 
         "add_properties": {
-          "cp_category_id": "1"
+          "cp_category_id": "1",
+          "cp_scale_factor": 0.001,
         }, 
       },
     },


### PR DESCRIPTION
… and annotation writing for bop toolkit writing
addresses #916; issue was that the pyrender wasn't aware of the object scale, and calculated camera position solely on `m2mm`. proposed solution includes a `scale_factor` property assigned to each object

https://github.com/wboerdijk/BlenderProc/blob/773b086b93098cf52201fb4bc9448434b63f58ec/blenderproc/python/loader/BopLoader.py#L353

and use this information to correctly position the camera

https://github.com/wboerdijk/BlenderProc/blob/773b086b93098cf52201fb4bc9448434b63f58ec/blenderproc/python/writer/BopWriterUtility.py#L587-L588

The cases which run successfully:
- object model in meters, `mm2m=False` during loading, both `m2mm=True` and `m2mm=False` work
- object model in mm: all combinations of `m2mm` and `mm2m`

NB:
- if one is not using the bop loader, the `scale_factor` cp has to be set if the model is scaled. we could also add it to the `obj.scale()` method directly?
- for `mm2m=False` and `m2mm=False` one might need to adapt the `distance_threshold`
- theoretically it works for loading object models in m and specifying `mm2m=True`, but various other stuff needs to be adapted for that, so please don't do that ;)

@cornerfarmer @MartinSmeyer tagging you here since i can't assign you as reviewer