### PR TITLE
feat(hdir): allows rotating hdri backgrounds

### DIFF
--- a/blenderproc/python/loader/HavenEnvironmentLoader.py
+++ b/blenderproc/python/loader/HavenEnvironmentLoader.py
@@ -3,13 +3,15 @@
 import glob
 import os
 import random
+from mathutils import Euler
 
 import bpy
 
 from blenderproc.python.utility.Utility import Utility
 
 
-def set_world_background_hdr_img(path_to_hdr_file: str, strength: float = 1.0):
+def set_world_background_hdr_img(path_to_hdr_file: str, strength: float = 1.0, 
+                                 rotation_euler: Union[list, Euler, np.ndarray] = [0.0, 0.0, 0.0]):
     """
     Sets the world background to the given hdr_file.
 
@@ -36,7 +38,18 @@ def set_world_background_hdr_img(path_to_hdr_file: str, strength: float = 1.0):
 
     # Set the brightness of the background
     background_node.inputs["Strength"].default_value = strength
+    
+    # add a mapping node and a texture coordinate node
+    mapping_node = nodes.new("ShaderNodeMapping") 
+    tex_coords_node = nodes.new("ShaderNodeTexCoord")
+    
+    #link the texture coordinate node to mapping node
+    links.new(tex_coords_node.outputs["Generated"], mapping_node.inputs["Vector"])
 
+    #link the mapping node to the texture node
+    links.new(mapping_node.outputs["Vector"], texture_node.inputs["Vector"])
+     
+    mapping_node.inputs["Rotation"].default_value = rotation_euler
 
 def get_random_world_background_hdr_img_path_from_haven(data_path: str) -> str:
     """ Sets the world background to a random .hdr file from the given directory.


### PR DESCRIPTION
add `rotation_eluer`  parameter to the `set_world_background_hdr_img` function.

Resolves: https://github.com/DLR-RM/BlenderProc/issues/941#issue-1814005456

closes #941