### PR TITLE
fix(flow): Fixes optical flow rgb output key

### DIFF
--- a/blenderproc/python/renderer/FlowRendererUtility.py
+++ b/blenderproc/python/renderer/FlowRendererUtility.py
@@ -59,7 +59,7 @@ def render_optical_flow(output_dir: str = None, temp_dir: str = None, get_forwar
         temporary_fwd_flow_file_path = os.path.join(temp_dir, 'fwd_flow_')
         temporary_bwd_flow_file_path = os.path.join(temp_dir, 'bwd_flow_')
         print(f"Rendering {bpy.context.scene.frame_end - bpy.context.scene.frame_start} frames of optical flow...")
-        RendererUtility.render(temp_dir, "bwd_flow_", None, load_keys=set(), verbose=verbose)
+        RendererUtility.render(temp_dir, "img_flow_temp_ignore_me_", None, load_keys=set(), verbose=verbose)
 
         # After rendering: convert to optical flow or calculate hsv visualization, if desired
         for frame in range(bpy.context.scene.frame_start, bpy.context.scene.frame_end):


### PR DESCRIPTION
RGB should now no longer overwrite optical flow output, even when output_format is set to exr.

Fixes: #684