### PR TITLE
fix: integer cast issue for colored projector patterns

### DIFF
--- a/blenderproc/python/types/LightUtility.py
+++ b/blenderproc/python/types/LightUtility.py
@@ -121,6 +121,7 @@ class Light(Entity):
         node_ox = nodes.get('Emission')
 
         image_data = bpy.data.images.new('pattern', width=pattern.shape[1], height=pattern.shape[0], alpha=True)
+        pattern = pattern / 255.0    # manual cast to range [0,1] to avoid integer casting issues below
         image_data.pixels = pattern.ravel()
 
         # Set Up Nodes

--- a/blenderproc/python/types/LightUtility.py
+++ b/blenderproc/python/types/LightUtility.py
@@ -121,7 +121,8 @@ class Light(Entity):
         node_ox = nodes.get('Emission')
 
         image_data = bpy.data.images.new('pattern', width=pattern.shape[1], height=pattern.shape[0], alpha=True)
-        pattern = pattern / 255.0    # manual cast to range [0,1] to avoid integer casting issues below
+        if pattern.dtype == np.uint8:
+            pattern = pattern / 255.0    # manual cast to range [0,1] to avoid integer casting issues below
         image_data.pixels = pattern.ravel()
 
         # Set Up Nodes


### PR DESCRIPTION
When calling _pattern.ravel()_, there is an issue with integer casting, which results in the array values being cast from floats to integers.  As a result, the end values are either 0 or 1, leading to the loss of color information and, consequently, the creation of an incorrect result image with only the color values cyan, yellow, and magenta. 