### PR TITLE
fix pools termination in BOP dataset generation

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,5 +1,5 @@
 {
-  "contributors": ["MartinSmeyer", "themasterlink", "cornerfarmer", "wboerdijk", "MarkusKnauer", "maximilianmuehlbauer", "wangg12", "alexander-soare", "heilaw", "5trobl", "marcelhohn", "ffurrer", "apenzko", "Victorlouisdg", "MarwinNumbers", "jascase901", "muedavid", "andrewyguo", "YouJiacheng", "Sebastian-Jung", "stevenpclark", "jung-se", "hansaskov", "HectorAnadon", "NnamdiN", "eliphatfs", "saprrow", "woodbridge", "fortminors", "beekama", "AndreyYashkin", "burcam"],
+  "contributors": ["MartinSmeyer", "themasterlink", "cornerfarmer", "wboerdijk", "MarkusKnauer", "maximilianmuehlbauer", "wangg12", "alexander-soare", "heilaw", "5trobl", "marcelhohn", "ffurrer", "apenzko", "Victorlouisdg", "MarwinNumbers", "jascase901", "muedavid", "andrewyguo", "YouJiacheng", "Sebastian-Jung", "stevenpclark", "jung-se", "hansaskov", "HectorAnadon", "NnamdiN", "eliphatfs", "saprrow", "woodbridge", "fortminors", "beekama", "AndreyYashkin", "burcam", "matteomastrogiuseppe"],
   "message": "For contributing to BlenderProc you need to sign our Contributor License Agreement. As an individual please sign [CLA_individuals.pdf](https://github.com/DLR-RM/BlenderProc/blob/main/CLA_individuals.pdf), as a company please sign [CLA_entities.pdf](https://github.com/DLR-RM/BlenderProc/blob/main/CLA_entities.pdf) and send it to blenderproc@dlr.de",
   "label": "cla-signed"
 }

--- a/blenderproc/python/writer/BopWriterUtility.py
+++ b/blenderproc/python/writer/BopWriterUtility.py
@@ -179,6 +179,10 @@ def write_bop(output_dir: str, target_objects: Optional[List[MeshObject]] = None
 
         _BopWriterUtility.calc_gt_coco(chunk_dirs=chunk_dirs, dataset_objects=dataset_objects,
                                        starting_frame_id=starting_frame_id)
+        
+        pool.close()
+        pool.join()
+
 
 
 def bop_pose_to_pyrender_coordinate_system(cam_R_m2c: np.ndarray, cam_t_m2c: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
See issue (https://github.com/DLR-RM/BlenderProc/issues/1084).

Pools are not explicitely closed, and in my case it leads to a progressive filling up of RAM memory. 
Manually calling the terminator shouldn't change anything, while at the same time avoiding potential issues. 