### PR TITLE
Blender 4.2.1

### DIFF
--- a/blenderproc/external/vhacd/decompose.py
+++ b/blenderproc/external/vhacd/decompose.py
@@ -150,7 +150,7 @@ def convex_decomposition(obj: "MeshObject", temp_dir: str, vhacd_path: str, reso
     else:
         out_file_name = os.path.join(cache_dir, str(mesh_hash) + ".obj")
 
-    bpy.ops.import_scene.obj(filepath=out_file_name, axis_forward="Y", axis_up="Z")
+    bpy.ops.wm.obj_import(filepath=out_file_name, forward_axis="Y", up_axis="Z")
     imported = bpy.context.selected_objects
 
     # Name and transform the loaded parts

--- a/blenderproc/python/camera/LensDistortionUtility.py
+++ b/blenderproc/python/camera/LensDistortionUtility.py
@@ -246,7 +246,7 @@ def apply_lens_distortion(image: Union[List[np.ndarray], np.ndarray],
             amount_of_output_channels = input_image.shape[2]
         image_distorted = np.zeros((orig_res_y, orig_res_x, amount_of_output_channels))
         used_dtpye = input_image.dtype
-        data = input_image.astype(np.float)
+        data = input_image.astype(np.float32)
         # Forward mapping in order to distort the undistorted image coordinates
         # and reshape the arrays into the image shape grid.
         # The reference frame for coords is as in DLR CalDe etc. (the upper-left pixel center is at [0,0])

--- a/blenderproc/python/loader/AMASSLoader.py
+++ b/blenderproc/python/loader/AMASSLoader.py
@@ -285,13 +285,12 @@ class _AMASSLoader:
                 skin_tone_fac = random.uniform(0.0, 1)
                 skin_tone_rgb = [value * skin_tone_fac for value in skin_tone_rgb]
                 principled_bsdf.inputs["Base Color"].default_value = mathutils.Vector([*skin_tone_rgb, 1.0])
-                principled_bsdf.inputs["Subsurface"].default_value = 0.2
-                principled_bsdf.inputs["Subsurface Color"].default_value = mathutils.Vector([*skin_tone_rgb, 1.0])
+                principled_bsdf.inputs["Subsurface Weight"].default_value = 0.2
                 principled_bsdf.inputs["Subsurface Radius"].default_value = mathutils.Vector([1.0, 0.2, 0.1])
-                principled_bsdf.inputs["Subsurface IOR"].default_value = 2.5
+                principled_bsdf.inputs["IOR"].default_value = 2.5
 
                 # darker skin looks better when made less specular
-                principled_bsdf.inputs["Specular"].default_value = np.mean(skin_tone_rgb) / 255.0
+                principled_bsdf.inputs["Specular IOR Level"].default_value = np.mean(skin_tone_rgb) / 255.0
 
                 texture_nodes = material.get_nodes_with_type("ShaderNodeTexImage")
                 if texture_nodes and len(texture_nodes) > 1:

--- a/blenderproc/python/loader/AMASSLoader.py
+++ b/blenderproc/python/loader/AMASSLoader.py
@@ -285,9 +285,12 @@ class _AMASSLoader:
                 skin_tone_fac = random.uniform(0.0, 1)
                 skin_tone_rgb = [value * skin_tone_fac for value in skin_tone_rgb]
                 principled_bsdf.inputs["Base Color"].default_value = mathutils.Vector([*skin_tone_rgb, 1.0])
-                principled_bsdf.inputs["Subsurface Weight"].default_value = 0.2
+
+                principled_bsdf.subsurface_method = "RANDOM_WALK_SKIN"
+                principled_bsdf.inputs["Subsurface Weight"].default_value = 1
+                principled_bsdf.inputs["Subsurface Scale"].default_value = 0.2
                 principled_bsdf.inputs["Subsurface Radius"].default_value = mathutils.Vector([1.0, 0.2, 0.1])
-                principled_bsdf.inputs["IOR"].default_value = 2.5
+                principled_bsdf.inputs["Subsurface IOR"].default_value = 2.5
 
                 # darker skin looks better when made less specular
                 principled_bsdf.inputs["Specular IOR Level"].default_value = np.mean(skin_tone_rgb) / 255.0

--- a/blenderproc/python/loader/BopLoader.py
+++ b/blenderproc/python/loader/BopLoader.py
@@ -347,6 +347,10 @@ class _BopLoader:
         # if the object was not previously loaded - load it, if duplication is allowed - duplicate it
         duplicated = model_path in _BopLoader.CACHED_OBJECTS
         objs = load_obj(model_path, cached_objects=_BopLoader.CACHED_OBJECTS)
+        # Bop objects comes with incorrect custom normals, so remove them
+        for obj in objs:
+            obj.clear_custom_splitnormals()
+            
         assert (
             len(objs) == 1
         ), f"Loading object from '{model_path}' returned more than one mesh"

--- a/blenderproc/python/loader/CCMaterialLoader.py
+++ b/blenderproc/python/loader/CCMaterialLoader.py
@@ -151,7 +151,7 @@ class _CCMaterialLoader:
         base_color = MaterialLoaderUtility.add_base_color(nodes, links, base_image_path, principled_bsdf)
         collection_of_texture_nodes.append(base_color)
 
-        principled_bsdf.inputs["Specular"].default_value = 0.333
+        principled_bsdf.inputs["Specular IOR Level"].default_value = 0.333
 
         ao_node = MaterialLoaderUtility.add_ambient_occlusion(nodes, links, ambient_occlusion_image_path,
                                                               principled_bsdf, base_color)

--- a/blenderproc/python/loader/Front3DLoader.py
+++ b/blenderproc/python/loader/Front3DLoader.py
@@ -368,11 +368,11 @@ class _Front3DLoader:
 
                         # Front3d .mtl files contain emission color which make the object mistakenly emissive
                         # => Reset the emission color
-                        principled_node.inputs["Emission"].default_value[:3] = [0, 0, 0]
+                        principled_node.inputs["Emission Color"].default_value[:3] = [0, 0, 0]
 
                         # Front3d .mtl files use Tf incorrectly, they make all materials fully transmissive
                         # Revert that:
-                        principled_node.inputs["Transmission"].default_value = 0
+                        principled_node.inputs["Transmission Weight"].default_value = 0
 
                         # For each a texture node
                         image_node = mat.new_node('ShaderNodeTexImage')

--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -40,8 +40,11 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
     # save all selected objects
     previously_selected_objects = bpy.context.selected_objects
     if filepath.endswith(".obj"):
+        # Set validate_meshes to False per default to be backwards compatible
+        if "validate_meshes" not in kwargs:
+            kwargs["validate_meshes"] = False
         # load an .obj file:
-        bpy.ops.wm.obj_import(filepath=filepath, **kwargs, validate_meshes=False)
+        bpy.ops.wm.obj_import(filepath=filepath, **kwargs)
     elif filepath.endswith(".ply"):
         PLY_TEXTURE_FILE_COMMENT = "comment TextureFile "
         model_name = os.path.basename(filepath)

--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -12,8 +12,7 @@ from blenderproc.python.material.MaterialLoaderUtility import create_material_fr
 from blenderproc.python.material.MaterialLoaderUtility import create as create_material
 
 
-def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]] = None,
-             use_legacy_obj_import: bool = False, **kwargs) -> List[MeshObject]:
+def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]] = None, **kwargs) -> List[MeshObject]:
     """ Import all objects for the given file and returns the loaded objects
 
     In .obj files a list of objects can be saved in.
@@ -22,8 +21,6 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
     :param filepath: the filepath to the location where the data is stored
     :param cached_objects: a dict of filepath to objects, which have been loaded before, to avoid reloading
                            (the dict is updated in this function)
-    :param use_legacy_obj_import: If this is true the old legacy obj importer in python is used. It is slower, but
-                                  it correctly imports the textures in the ShapeNet dataset.
     :param kwargs: all other params are handed directly to the bpy loading fct. check the corresponding documentation
     :return: The list of loaded mesh objects.
     """
@@ -44,10 +41,7 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
     previously_selected_objects = bpy.context.selected_objects
     if filepath.endswith(".obj"):
         # load an .obj file:
-        if use_legacy_obj_import:
-            bpy.ops.import_scene.obj(filepath=filepath, **kwargs)
-        else:
-            bpy.ops.wm.obj_import(filepath=filepath, **kwargs)
+        bpy.ops.wm.obj_import(filepath=filepath, **kwargs)
     elif filepath.endswith(".ply"):
         PLY_TEXTURE_FILE_COMMENT = "comment TextureFile "
         model_name = os.path.basename(filepath)

--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -41,7 +41,7 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
     previously_selected_objects = bpy.context.selected_objects
     if filepath.endswith(".obj"):
         # load an .obj file:
-        bpy.ops.wm.obj_import(filepath=filepath, **kwargs)
+        bpy.ops.wm.obj_import(filepath=filepath, **kwargs, validate_meshes=False)
     elif filepath.endswith(".ply"):
         PLY_TEXTURE_FILE_COMMENT = "comment TextureFile "
         model_name = os.path.basename(filepath)

--- a/blenderproc/python/loader/ObjectLoader.py
+++ b/blenderproc/python/loader/ObjectLoader.py
@@ -72,11 +72,11 @@ def load_obj(filepath: str, cached_objects: Optional[Dict[str, List[MeshObject]]
                 file.write(new_ply_file_content)
 
             # Load .ply mesh
-            bpy.ops.import_mesh.ply(filepath=tmp_ply_file, **kwargs)
+            bpy.ops.wm.ply_import(filepath=tmp_ply_file, **kwargs)
 
         else:  # If no texture was given
             # load a .ply mesh
-            bpy.ops.import_mesh.ply(filepath=filepath, **kwargs)
+            bpy.ops.wm.ply_import(filepath=filepath, **kwargs)
             # Create default material
             material = create_material('ply_material')
             material.map_vertex_color()

--- a/blenderproc/python/loader/ReplicaLoader.py
+++ b/blenderproc/python/loader/ReplicaLoader.py
@@ -135,6 +135,9 @@ def load_replica(data_path: str, data_set_name: str, use_smooth_shading: bool = 
     """
     file_path = os.path.join(data_path, data_set_name, 'mesh.ply')
     loaded_objects = load_obj(file_path)
+    # Replica comes with incorrect custom normals, so remove them
+    for obj in loaded_objects:
+        obj.clear_custom_splitnormals()
 
     if use_smooth_shading:
         for obj in loaded_objects:

--- a/blenderproc/python/loader/ShapeNetLoader.py
+++ b/blenderproc/python/loader/ShapeNetLoader.py
@@ -39,7 +39,7 @@ def load_shapenet(data_path: str, used_synset_id: str, used_source_id: str = "",
                                                                       taxonomy_file_path, data_path)
     selected_obj = random.choice(files_with_fitting_synset)
     # with the new version the textures are all wrong
-    loaded_objects = load_obj(selected_obj, use_legacy_obj_import=True)
+    loaded_objects = load_obj(selected_obj)
 
     # In shapenet every .obj file only contains one object, make sure that is the case
     if len(loaded_objects) != 1:

--- a/blenderproc/python/loader/ShapeNetLoader.py
+++ b/blenderproc/python/loader/ShapeNetLoader.py
@@ -14,7 +14,7 @@ from blenderproc.python.loader.ObjectLoader import load_obj
 
 
 def load_shapenet(data_path: str, used_synset_id: str, used_source_id: str = "",
-                  move_object_origin: bool = True, validate_meshes: bool = False) -> MeshObject:
+                  move_object_origin: bool = True, validate_meshes: bool = True) -> MeshObject:
     """ This loads an object from ShapeNet based on the given synset_id, which specifies the category of objects to use.
 
     From these objects one is randomly sampled and loaded.
@@ -32,6 +32,7 @@ def load_shapenet(data_path: str, used_synset_id: str, used_source_id: str = "",
                                Default: True
     :param validate_meshes: If set to True, imported meshed will be validated and corrected.
                             This might help for some ShapeNet objects to e.g. remove duplicate faces.
+                            However, it might lead to the texturing being destroyed.
     :return: The loaded mesh object.
     """
     data_path = resolve_path(data_path)

--- a/blenderproc/python/loader/ShapeNetLoader.py
+++ b/blenderproc/python/loader/ShapeNetLoader.py
@@ -14,7 +14,7 @@ from blenderproc.python.loader.ObjectLoader import load_obj
 
 
 def load_shapenet(data_path: str, used_synset_id: str, used_source_id: str = "",
-                  move_object_origin: bool = True, validate_meshes: bool = True) -> MeshObject:
+                  move_object_origin: bool = True, validate_meshes: bool = False) -> MeshObject:
     """ This loads an object from ShapeNet based on the given synset_id, which specifies the category of objects to use.
 
     From these objects one is randomly sampled and loaded.

--- a/blenderproc/python/loader/ShapeNetLoader.py
+++ b/blenderproc/python/loader/ShapeNetLoader.py
@@ -14,7 +14,7 @@ from blenderproc.python.loader.ObjectLoader import load_obj
 
 
 def load_shapenet(data_path: str, used_synset_id: str, used_source_id: str = "",
-                  move_object_origin: bool = True) -> MeshObject:
+                  move_object_origin: bool = True, validate_meshes: bool = False) -> MeshObject:
     """ This loads an object from ShapeNet based on the given synset_id, which specifies the category of objects to use.
 
     From these objects one is randomly sampled and loaded.
@@ -30,6 +30,8 @@ def load_shapenet(data_path: str, used_synset_id: str, used_source_id: str = "",
     :param move_object_origin: Moves the object center to the bottom of the bounding box in Z direction and also in the
                                middle of the X and Y plane, this does not change the `.location` of the object.
                                Default: True
+    :param validate_meshes: If set to True, imported meshed will be validated and corrected.
+                            This might help for some ShapeNet objects to e.g. remove duplicate faces.
     :return: The loaded mesh object.
     """
     data_path = resolve_path(data_path)
@@ -39,7 +41,7 @@ def load_shapenet(data_path: str, used_synset_id: str, used_source_id: str = "",
                                                                       taxonomy_file_path, data_path)
     selected_obj = random.choice(files_with_fitting_synset)
     # with the new version the textures are all wrong
-    loaded_objects = load_obj(selected_obj)
+    loaded_objects = load_obj(selected_obj, validate_meshes=validate_meshes)
 
     # In shapenet every .obj file only contains one object, make sure that is the case
     if len(loaded_objects) != 1:

--- a/blenderproc/python/material/Dust.py
+++ b/blenderproc/python/material/Dust.py
@@ -156,10 +156,17 @@ def add_dust(material: Material, strength: float, texture_nodes: List[bpy.types.
     group_input.location = (x_pos + x_diff * 7, y_pos - y_diff * 0.5)
 
     # create sockets for the outside of the group match them to the mix shader
-    group.outputs.new(mix_shader.outputs[0].bl_idname, mix_shader.outputs[0].name)
-    group.inputs.new(mix_shader.inputs[1].bl_idname, mix_shader.inputs[1].name)
-    group.inputs.new(multiply_node.inputs[1].bl_idname, "Dust strength")
-    group.inputs.new(mapping_node.inputs["Scale"].bl_idname, "Texture scale")
+    group.interface.new_socket(
+        mix_shader.outputs[0].name, in_out='OUTPUT', socket_type=mix_shader.outputs[0].bl_idname)
+    group.interface.new_socket(
+        mix_shader.inputs[1].name, in_out='INPUT', socket_type=mix_shader.inputs[1].bl_idname)
+    group.interface.new_socket(
+        "Dust strength", in_out='INPUT', socket_type=multiply_node.inputs[1].bl_idname)
+    # We set the socket_type='NodeSocketVector' directly instead of using
+    # 'mapping.node.inputs["Scale"].bl_idname', because the 'Scale' has a specific bl_idname of
+    # 'NodeSocketVectorXYZ', but 'new_socket' expects 'NodeSocketVector'.
+    group.interface.new_socket(
+        "Texture scale", in_out='INPUT', socket_type='NodeSocketVector')
 
     # link the input and output to the mix shader
     links.new(group_input.outputs[0], mix_shader.inputs[1])

--- a/blenderproc/python/material/Dust.py
+++ b/blenderproc/python/material/Dust.py
@@ -146,7 +146,7 @@ def add_dust(material: Material, strength: float, texture_nodes: List[bpy.types.
     # the used dust color is a grey with a tint in orange
     dust_color.inputs["Base Color"].default_value = [0.8, 0.773, 0.7, 1.0]
     dust_color.inputs["Roughness"].default_value = 1.0
-    dust_color.inputs["Specular"].default_value = 0.0
+    dust_color.inputs["Specular IOR Level"].default_value = 0.0
     links.new(dust_color.outputs["BSDF"], mix_shader.inputs[2])
 
     # create the input and output nodes inside of the group

--- a/blenderproc/python/material/MaterialLoaderUtility.py
+++ b/blenderproc/python/material/MaterialLoaderUtility.py
@@ -227,7 +227,7 @@ def add_specular(nodes: bpy.types.Nodes, links: bpy.types.NodeLinks, specular_im
     if os.path.exists(specular_image_path):
         specular_texture = create_image_node(nodes, specular_image_path, True,
                                              _x_texture_node, 0)
-        links.new(specular_texture.outputs["Color"], principled_bsdf.inputs["Specular"])
+        links.new(specular_texture.outputs["Color"], principled_bsdf.inputs["Specular IOR Level"])
         return specular_texture
     return None
 
@@ -482,7 +482,7 @@ def change_to_texture_less_render(use_alpha_channel):
     principled_bsdf = Utility.get_the_one_node_with_type(nodes, "BsdfPrincipled")
 
     # setting the color values for the shader
-    principled_bsdf.inputs['Specular'].default_value = 0.65  # specular
+    principled_bsdf.inputs['Specular IOR Level'].default_value = 0.65  # specular
     principled_bsdf.inputs['Roughness'].default_value = 0.2  # roughness
 
     for used_object in [obj for obj in bpy.context.scene.objects if hasattr(obj.data, 'materials')]:

--- a/blenderproc/python/material/MaterialLoaderUtility.py
+++ b/blenderproc/python/material/MaterialLoaderUtility.py
@@ -347,7 +347,7 @@ def add_displacement(nodes: bpy.types.Nodes, links: bpy.types.NodeLinks, displac
                                                  _y_texture_node * -4)
         displacement_node = nodes.new("ShaderNodeDisplacement")
         displacement_node.inputs["Midlevel"].default_value = 0.5
-        displacement_node.inputs["Scale"].default_value = 0.15
+        displacement_node.inputs["Scale"].default_value = 0.03
         displacement_node.location.x = _x_texture_node * 0.5
         displacement_node.location.y = _y_texture_node * -4
         links.new(displacement_texture.outputs["Color"], displacement_node.inputs["Height"])

--- a/blenderproc/python/object/PhysicsSimulation.py
+++ b/blenderproc/python/object/PhysicsSimulation.py
@@ -47,7 +47,8 @@ def simulate_physics_and_fix_final_poses(min_simulation_time: float = 4.0, max_s
         obj_poses_after_sim = _PhysicsSimulation.get_pose()
 
         # Make sure to remove the simulation cache as we are only interested in the final poses
-        bpy.ops.ptcache.free_bake({"point_cache": bpy.context.scene.rigidbody_world.point_cache})
+        with bpy.context.temp_override(point_cache=bpy.context.scene.rigidbody_world.point_cache):
+            bpy.ops.ptcache.free_bake()
 
     # Fix the pose of all objects to their pose at the end of the simulation (also revert origin shift)
     for obj in get_all_mesh_objects():
@@ -184,7 +185,8 @@ class _PhysicsSimulation:
             # Simulate current interval
             point_cache.frame_end = current_frame
             with stdout_redirected(enabled=not verbose):
-                bpy.ops.ptcache.bake({"point_cache": point_cache}, bake=True)
+                with bpy.context.temp_override(point_cache=point_cache):
+                    bpy.ops.ptcache.bake(bake=True)
 
             # Go to second last frame and get poses
             bpy.context.scene.frame_set(current_frame - _PhysicsSimulation.seconds_to_frames(1))
@@ -205,7 +207,8 @@ class _PhysicsSimulation:
             else:
                 # Free bake (this will not completely remove the simulation cache, so further simulations can
                 # reuse the already calculated frames)
-                bpy.ops.ptcache.free_bake({"point_cache": point_cache})
+                with bpy.context.temp_override(point_cache=point_cache):
+                    bpy.ops.ptcache.free_bake()
 
     @staticmethod
     def get_pose() -> dict:

--- a/blenderproc/python/object/PhysicsSimulation.py
+++ b/blenderproc/python/object/PhysicsSimulation.py
@@ -13,7 +13,7 @@ def simulate_physics_and_fix_final_poses(min_simulation_time: float = 4.0, max_s
                                          check_object_interval: float = 2.0,
                                          object_stopped_location_threshold: float = 0.01,
                                          object_stopped_rotation_threshold: float = 0.1, substeps_per_frame: int = 10,
-                                         solver_iters: int = 10, verbose: bool = False):
+                                         solver_iters: int = 10, verbose: bool = False, use_volume_com: bool = False):
     """ Simulates the current scene and in the end fixes the final poses of all active objects.
 
     The simulation is run for at least `min_simulation_time` seconds and at a maximum `max_simulation_time` seconds.
@@ -36,6 +36,8 @@ def simulate_physics_and_fix_final_poses(min_simulation_time: float = 4.0, max_s
     :param substeps_per_frame: Number of simulation steps taken per frame.
     :param solver_iters: Number of constraint solver iterations made per simulation step.
     :param verbose: If True, more details during the physics simulation are printed.
+    :param use_volume_com: If True, the center of mass will be calculated by using the object volume.
+                           This is more accurate than using the surface area (default), but requires a watertight mesh.
     """
     # Undo changes made in the simulation like origin adjustment and persisting the object's scale
     with UndoAfterExecution():
@@ -43,7 +45,7 @@ def simulate_physics_and_fix_final_poses(min_simulation_time: float = 4.0, max_s
         obj_poses_before_sim = _PhysicsSimulation.get_pose()
         origin_shifts = simulate_physics(min_simulation_time, max_simulation_time, check_object_interval,
                                          object_stopped_location_threshold, object_stopped_rotation_threshold,
-                                         substeps_per_frame, solver_iters, verbose)
+                                         substeps_per_frame, solver_iters, verbose, use_volume_com)
         obj_poses_after_sim = _PhysicsSimulation.get_pose()
 
         # Make sure to remove the simulation cache as we are only interested in the final poses
@@ -77,7 +79,7 @@ def simulate_physics_and_fix_final_poses(min_simulation_time: float = 4.0, max_s
 def simulate_physics(min_simulation_time: float = 4.0, max_simulation_time: float = 40.0,
                      check_object_interval: float = 2.0, object_stopped_location_threshold: float = 0.01,
                      object_stopped_rotation_threshold: float = 0.1, substeps_per_frame: int = 10,
-                     solver_iters: int = 10, verbose: bool = False) -> dict:
+                     solver_iters: int = 10, verbose: bool = False, use_volume_com: bool = False) -> dict:
     """ Simulates the current scene.
 
     The simulation is run for at least `min_simulation_time` seconds and at a maximum `max_simulation_time` seconds.
@@ -101,6 +103,8 @@ def simulate_physics(min_simulation_time: float = 4.0, max_simulation_time: floa
     :param substeps_per_frame: Number of simulation steps taken per frame.
     :param solver_iters: Number of constraint solver iterations made per simulation step.
     :param verbose: If True, more details during the physics simulation are printed.
+    :param use_volume_com: If True, the center of mass will be calculated by using the object volume.
+                           This is more accurate than using the surface area (default), but requires a watertight mesh.
     :return: A dict containing for every active object the shift that was added to their origins.
     """
     # Shift the origin of all objects to their center of mass to make the simulation more realistic
@@ -108,7 +112,7 @@ def simulate_physics(min_simulation_time: float = 4.0, max_simulation_time: floa
     for obj in get_all_mesh_objects():
         if obj.has_rigidbody_enabled():
             prev_origin = obj.get_origin()
-            new_origin = obj.set_origin(mode="CENTER_OF_VOLUME")
+            new_origin = obj.set_origin(mode="ORIGIN_CENTER_OF_VOLUME" if use_volume_com else "CENTER_OF_MASS")
             origin_shift[obj.get_name()] = new_origin - prev_origin
 
             # Persist mesh scaling as having a scale != 1 can make the simulation unstable

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -654,7 +654,6 @@ def _render_progress_bar(pipe_out: int, pipe_in: int, stdout: IO, total_frames: 
 def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_key: Optional[str] = "colors",
            load_keys: Optional[Set[str]] = None, return_data: bool = True,
            keys_with_alpha_channel: Optional[Set[str]] = None,
-           view_transform: str = "Filmic",
            verbose: bool = False) -> Dict[str, Union[np.ndarray, List[np.ndarray]]]:
     """ Render all frames.
 
@@ -667,7 +666,6 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
     :param load_keys: Set of output keys to load when available
     :param return_data: Whether to load and return generated data.
     :param keys_with_alpha_channel: A set containing all keys whose alpha channels should be loaded.
-    :param view_transform: Determines the view transform to use for rendering.
     :param verbose: If True, more details about the rendering process are printed.
     :return: dict of lists of raw renderer output. Keys can be 'distance', 'colors', 'normals'
     """
@@ -677,10 +675,6 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
         load_keys = {'colors', 'distance', 'normals', 'diffuse', 'depth', 'segmap'}
         keys_with_alpha_channel = {'colors'} if bpy.context.scene.render.film_transparent else None
 
-    if view_transform not in {"AgX", "Standard", "Filmic", "Filmic Log", "False Color", "Raw"}:
-        raise ValueError(f"Unknown view transform {view_transform}")
-    
-    bpy.context.scene.view_settings.view_transform = view_transform
     if output_key is not None:
         Utility.add_output_entry({
             "key": output_key,
@@ -736,7 +730,8 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
 
 
 def set_output_format(file_format: Optional[str] = None, color_depth: Optional[int] = None,
-                      enable_transparency: Optional[bool] = None, jpg_quality: Optional[int] = None):
+                      enable_transparency: Optional[bool] = None, jpg_quality: Optional[int] = None,
+                      view_transform: Optional[str] = None):
     """ Sets the output format to use for rendering. Default values defined in DefaultConfig.py.
 
     :param file_format: The file format to use, e.q. "PNG", "JPEG" or "OPEN_EXR".
@@ -744,6 +739,7 @@ def set_output_format(file_format: Optional[str] = None, color_depth: Optional[i
     :param enable_transparency: If true, the output will contain a alpha channel and the background will be
                                 set transparent.
     :param jpg_quality: The quality to use, if file format is set to "JPEG".
+    :param view_transform: View transform of the rendered output.
     """
     if enable_transparency is not None:
         # In case a previous renderer changed these settings
@@ -758,6 +754,8 @@ def set_output_format(file_format: Optional[str] = None, color_depth: Optional[i
     if jpg_quality is not None:
         # only influences jpg quality
         bpy.context.scene.render.image_settings.quality = jpg_quality
+    if view_transform is not None:
+        bpy.context.scene.view_settings.view_transform = view_transform
 
 
 def enable_motion_blur(motion_blur_length: float = 0.5, rolling_shutter_type: str = "NONE",

--- a/blenderproc/python/renderer/RendererUtility.py
+++ b/blenderproc/python/renderer/RendererUtility.py
@@ -654,6 +654,7 @@ def _render_progress_bar(pipe_out: int, pipe_in: int, stdout: IO, total_frames: 
 def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_key: Optional[str] = "colors",
            load_keys: Optional[Set[str]] = None, return_data: bool = True,
            keys_with_alpha_channel: Optional[Set[str]] = None,
+           view_transform: str = "Filmic",
            verbose: bool = False) -> Dict[str, Union[np.ndarray, List[np.ndarray]]]:
     """ Render all frames.
 
@@ -666,6 +667,7 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
     :param load_keys: Set of output keys to load when available
     :param return_data: Whether to load and return generated data.
     :param keys_with_alpha_channel: A set containing all keys whose alpha channels should be loaded.
+    :param view_transform: Determines the view transform to use for rendering.
     :param verbose: If True, more details about the rendering process are printed.
     :return: dict of lists of raw renderer output. Keys can be 'distance', 'colors', 'normals'
     """
@@ -675,6 +677,10 @@ def render(output_dir: Optional[str] = None, file_prefix: str = "rgb_", output_k
         load_keys = {'colors', 'distance', 'normals', 'diffuse', 'depth', 'segmap'}
         keys_with_alpha_channel = {'colors'} if bpy.context.scene.render.film_transparent else None
 
+    if view_transform not in {"AgX", "Standard", "Filmic", "Filmic Log", "False Color", "Raw"}:
+        raise ValueError(f"Unknown view transform {view_transform}")
+    
+    bpy.context.scene.view_settings.view_transform = view_transform
     if output_key is not None:
         Utility.add_output_entry({
             "key": output_key,

--- a/blenderproc/python/types/EntityUtility.py
+++ b/blenderproc/python/types/EntityUtility.py
@@ -236,7 +236,8 @@ class Entity(Struct):
         selected_objects = [self]
         if remove_all_offspring:
             selected_objects.extend(self.get_children(return_all_offspring=True))
-        bpy.ops.object.delete({"selected_objects": [e.blender_obj for e in selected_objects]})
+        with bpy.context.temp_override(selected_objects=[e.blender_obj for e in selected_objects]):
+            bpy.ops.object.delete()
 
     def is_empty(self) -> bool:
         """ Returns whether the entity is from type "EMPTY".
@@ -338,6 +339,8 @@ def delete_multiple(entities: List[Union["Entity"]], remove_all_offspring: bool 
             all_nodes.extend(entity.get_children(return_all_offspring=True))
         # avoid doubles
         all_nodes = set(all_nodes)
-        bpy.ops.object.delete({"selected_objects": [e.blender_obj for e in all_nodes]})
+        with bpy.context.temp_override(selected_objects=[e.blender_obj for e in all_nodes]):
+            bpy.ops.object.delete()
     else:
-        bpy.ops.object.delete({"selected_objects": [e.blender_obj for e in entities]})
+        with bpy.context.temp_override(selected_objects=[e.blender_obj for e in entities]):
+            bpy.ops.object.delete()

--- a/blenderproc/python/types/LightUtility.py
+++ b/blenderproc/python/types/LightUtility.py
@@ -113,7 +113,7 @@ class Light(Entity):
         self.blender_obj.data.use_nodes = True
         self.blender_obj.data.shadow_soft_size = 0
         self.blender_obj.data.spot_size = 3.14159  # 180deg in rad
-        self.blender_obj.data.cycles.cast_shadow = False
+        self.blender_obj.data.use_shadow = False
 
         nodes = self.blender_obj.data.node_tree.nodes
         links = self.blender_obj.data.node_tree.links

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -545,7 +545,7 @@ class MeshObject(Entity):
             modifier.node_group = existing_node_group
 
         modifier = self.blender_obj.modifiers["Smooth by Angle"]
-        modifier["Input_1"] = float(angle)
+        modifier["Input_1"] = np.deg2rad(float(angle))
 
     def mesh_as_trimesh(self) -> Trimesh:
          """ Returns a trimesh.Trimesh instance of the MeshObject.

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -17,6 +17,7 @@ from blenderproc.python.utility.Utility import Utility, resolve_path
 from blenderproc.python.utility.BlenderUtility import get_all_blender_mesh_objects
 from blenderproc.python.types.MaterialUtility import Material
 from blenderproc.python.material import MaterialLoaderUtility
+from blenderproc.python.utility.SetupUtility import SetupUtility
 
 if platform != "win32":
     # this is only supported under linux and macOS, the import itself already doesn't work under windows
@@ -520,8 +521,9 @@ class MeshObject(Entity):
         # So we load the node group and create the modifier ourselves.
         # Known issue: https://projects.blender.org/blender/blender/issues/117399
 
-        # The datafiles are expected to be in the same folder as the 'blender_binary/version'.
-        path = Path(bpy.app.binary_path).parent / "4.2" / "datafiles" / "assets" / "geometry_nodes" / "smooth_by_angle.blend"
+        # The datafiles are expected to be in the same folder relative to blender's python binary.
+        python_bin = SetupUtility.determine_python_paths(None, None)[0]
+        path = Path(python_bin).parent.parent.parent / "datafiles" / "assets" / "geometry_nodes" / "smooth_by_angle.blend"
         if not path.exists():
             raise RuntimeError(f"Could not find the path to the 'ESSENTIALS' asset folder expected at {path}")
         

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -515,10 +515,9 @@ class MeshObject(Entity):
         """
         with bpy.context.temp_override(object=self.blender_obj):
             bpy.ops.object.modifier_add_node_group(
-                asset_library_type='CUSTOM',
-                asset_library_identifier="assets",
-                relative_asset_identifier="geometry_nodes/smooth_by_angle.blend/NodeTree/Smooth by Angle"
-            )
+                asset_library_type='ESSENTIALS',
+                asset_library_identifier="",
+                relative_asset_identifier="geometry_nodes/smooth_by_angle.blend/NodeTree/Smooth by Angle")
 
         modifier = self.blender_obj.modifiers[-1]
         modifier["Input_1"] = float(angle)

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -575,6 +575,12 @@ class MeshObject(Entity):
     
          return Trimesh(vertices=verts, faces=faces)
 
+    def clear_custom_splitnormals(self) -> None:
+        """ Removes custom split normals which might exist after importing the object from file. """
+
+        with bpy.context.temp_override(object=self.blender_obj):
+            bpy.ops.mesh.customdata_custom_splitnormals_clear()
+
 def create_from_blender_mesh(blender_mesh: bpy.types.Mesh, object_name: str = None) -> "MeshObject":
     """ Creates a new Mesh object using the given blender mesh.
 

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -513,6 +513,8 @@ class MeshObject(Entity):
         """ Adds the 'Smooth by Angle' geometry nodes modifier.
         
         This replaces the 'Auto Smooth' behavior available in Blender before 4.1.
+
+        :param angle: Maximum angle (in degrees) between face normals that will be considered as smooth.
         """
         # The bpy.ops.object.modifier_add_node_group doesn't work in background mode :( 
         # So we load the node group and create the modifier ourselves.

--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -96,14 +96,11 @@ class MeshObject(Entity):
         """
         if mode.lower() == "flat":
             is_smooth = False
-            self.blender_obj.data.use_auto_smooth = False
         elif mode.lower() == "smooth":
             is_smooth = True
-            self.blender_obj.data.use_auto_smooth = False
         elif mode.lower() == "auto":
             is_smooth = True
-            self.blender_obj.data.use_auto_smooth = True
-            self.blender_obj.data.auto_smooth_angle = np.deg2rad(angle_value)
+            self.add_auto_smooth_modifier(angle=angle_value)
         else:
             raise RuntimeError(f"This shading mode is unknown: {mode}")
 
@@ -510,6 +507,21 @@ class MeshObject(Entity):
             bpy.ops.node.new_geometry_nodes_modifier()
         modifier = self.blender_obj.modifiers[-1]
         return modifier.node_group
+
+    def add_auto_smooth_modifier(self, angle: float = 30.0):
+        """ Adds the 'Smooth by Angle' geometry nodes modifier.
+        
+        This replaces the 'Auto Smooth' behavior available in Blender before 4.1.
+        """
+        with bpy.context.temp_override(object=self.blender_obj):
+            bpy.ops.object.modifier_add_node_group(
+                asset_library_type='CUSTOM',
+                asset_library_identifier="assets",
+                relative_asset_identifier="geometry_nodes/smooth_by_angle.blend/NodeTree/Smooth by Angle"
+            )
+
+        modifier = self.blender_obj.modifiers[-1]
+        modifier["Input_1"] = float(angle)
 
     def mesh_as_trimesh(self) -> Trimesh:
          """ Returns a trimesh.Trimesh instance of the MeshObject.

--- a/blenderproc/python/utility/BlenderUtility.py
+++ b/blenderproc/python/utility/BlenderUtility.py
@@ -368,7 +368,7 @@ def add_nodes_to_group(nodes: bpy.types.Node, group_name: str) -> bpy.types.Shad
     material_outputs = Utility.get_nodes_with_type(group.nodes, "OutputMaterial")
     if len(material_outputs) == 1:
         for input_node in material_outputs[0].inputs:
-            group.outputs.new(input_node.bl_idname, input_node.name)
+            group.interface.new_socket(input_node.name, in_out='OUTPUT', socket_type=input_node.bl_idname)
             for link in input_node.links:
                 group.links.new(link.from_socket, group_output.inputs[input_node.name])
         # remove the material output, the material output should never be inside of a group

--- a/blenderproc/python/utility/DefaultConfig.py
+++ b/blenderproc/python/utility/DefaultConfig.py
@@ -41,6 +41,7 @@ class DefaultConfig:
     volume_bounces = 0
     antialiasing_distance_max = 10000
     world_background = [0.05, 0.05, 0.05]
+    view_transform = "Filmic"
 
     # Setup
     default_pip_packages = ["wheel", "pyyaml==6.0.1", "imageio==2.34.1", "gitpython==3.1.43",

--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -74,6 +74,10 @@ def clean_up(clean_up_camera: bool = False):
     _Initializer.remove_all_data(clean_up_camera)
     _Initializer.remove_custom_properties()
 
+    # Make the default 'LayerCollection' as active, so bpy.context.collection points to it.
+    # This is the 'Scene Collection' in the outliner.
+    bpy.context.view_layer.active_layer_collection = bpy.context.view_layer.layer_collection
+    
     # Create new world
     new_world = bpy.data.worlds.new("World")
     bpy.context.scene.world = new_world

--- a/blenderproc/python/utility/Initializer.py
+++ b/blenderproc/python/utility/Initializer.py
@@ -138,7 +138,8 @@ class _Initializer:
         RendererUtility.set_output_format(DefaultConfig.file_format,
                                           DefaultConfig.color_depth,
                                           DefaultConfig.enable_transparency,
-                                          DefaultConfig.jpg_quality)
+                                          DefaultConfig.jpg_quality,
+                                          DefaultConfig.view_transform)
 
     @staticmethod
     def remove_all_data(remove_camera: bool = True):

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -78,7 +78,7 @@ class InstallUtility:
                 blender_install_path = "blender"
 
             # Determine configured version
-            # right new only support blender-3.5.1
+            # right now only support blender-4.0.2
             major_version = "4.0"
             minor_version = "2"
             blender_version = f"blender-{major_version}.{minor_version}"

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -78,9 +78,9 @@ class InstallUtility:
                 blender_install_path = "blender"
 
             # Determine configured version
-            # right now only support blender-4.2.0
+            # right now only support blender-4.2.1
             major_version = "4.2"
-            minor_version = "0"
+            minor_version = "1"
             blender_version = f"blender-{major_version}.{minor_version}"
             if platform in ["linux", "linux2"]:
                 blender_version += "-linux-x64"

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -79,8 +79,8 @@ class InstallUtility:
 
             # Determine configured version
             # right new only support blender-3.5.1
-            major_version = "3.6"
-            minor_version = "14"
+            major_version = "4.0"
+            minor_version = "2"
             blender_version = f"blender-{major_version}.{minor_version}"
             if platform in ["linux", "linux2"]:
                 blender_version += "-linux-x64"

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -79,8 +79,8 @@ class InstallUtility:
 
             # Determine configured version
             # right new only support blender-3.5.1
-            major_version = "3.5"
-            minor_version = "1"
+            major_version = "3.6"
+            minor_version = "14"
             blender_version = f"blender-{major_version}.{minor_version}"
             if platform in ["linux", "linux2"]:
                 blender_version += "-linux-x64"

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -78,9 +78,9 @@ class InstallUtility:
                 blender_install_path = "blender"
 
             # Determine configured version
-            # right now only support blender-4.1.1
-            major_version = "4.1"
-            minor_version = "1"
+            # right now only support blender-4.2.0
+            major_version = "4.2"
+            minor_version = "0"
             blender_version = f"blender-{major_version}.{minor_version}"
             if platform in ["linux", "linux2"]:
                 blender_version += "-linux-x64"

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -9,7 +9,7 @@ import shutil
 from sys import platform, version_info
 import ssl
 from platform import machine
-from typing import Union, Tuple
+from typing import Union, Tuple, Optional
 
 if version_info.major == 3:
     from urllib.request import urlretrieve, build_opener, install_opener
@@ -47,7 +47,7 @@ class InstallUtility:
         return custom_blender_path, blender_install_path
 
     @staticmethod
-    def make_sure_blender_is_installed(custom_blender_path: str, blender_install_path: str,
+    def make_sure_blender_is_installed(custom_blender_path: Optional[str], blender_install_path: str,
                                        reinstall_blender: bool = False) -> Tuple[str, str]:
         """ Make sure blender is installed.
 

--- a/blenderproc/python/utility/InstallUtility.py
+++ b/blenderproc/python/utility/InstallUtility.py
@@ -78,9 +78,9 @@ class InstallUtility:
                 blender_install_path = "blender"
 
             # Determine configured version
-            # right now only support blender-4.0.2
-            major_version = "4.0"
-            minor_version = "2"
+            # right now only support blender-4.1.1
+            major_version = "4.1"
+            minor_version = "1"
             blender_version = f"blender-{major_version}.{minor_version}"
             if platform in ["linux", "linux2"]:
                 blender_version += "-linux-x64"

--- a/blenderproc/python/utility/SetupUtility.py
+++ b/blenderproc/python/utility/SetupUtility.py
@@ -98,7 +98,7 @@ class SetupUtility:
             major_version = os.path.basename(os.path.abspath(os.path.join(os.path.dirname(sys.executable), "..", "..")))
 
         # Based on the OS determined the three paths
-        current_python_version = "python3.10"
+        current_python_version = "python3.11"
         if platform in ["linux", "linux2"]:
             python_bin_folder = os.path.join(blender_path, major_version, "python", "bin")
             python_bin = os.path.join(python_bin_folder, current_python_version)

--- a/blenderproc/python/writer/GifWriterUtility.py
+++ b/blenderproc/python/writer/GifWriterUtility.py
@@ -6,6 +6,9 @@ import os
 import bpy
 import numpy as np
 from PIL import Image
+# Make sure we use headless matplotlib
+import matplotlib
+matplotlib.use("agg")
 
 from blenderproc.scripts.visHdf5Files import vis_data
 from blenderproc.python.utility.Utility import Utility

--- a/docs/run.py
+++ b/docs/run.py
@@ -4,7 +4,7 @@ import os
 from shutil import which
 
 # Add path to custom packages inside the blender main directory
-sys.path.append(os.path.join(os.path.dirname(sys.executable), "..", "..", "..", "custom-python-packages/lib/python3.10/site-packages/"))
+sys.path.append(os.path.join(os.path.dirname(sys.executable), "..", "..", "..", "custom-python-packages/python3.11/site-packages/"))
 
 # Determine abs path to sphinx-build
 sphinx_build_bin_path = os.path.join(os.path.dirname(sys.executable), "..", "..", "..", "custom-python-packages", "bin", "sphinx-build")

--- a/examples/advanced/auto_shading/main.py
+++ b/examples/advanced/auto_shading/main.py
@@ -15,7 +15,7 @@ objs = bproc.loader.load_blend(args.scene)
 # Change specular and roughness factor of all objects, so the shading will be better visible
 for obj in objs:
     for mat in obj.get_materials():
-        mat.set_principled_shader_value("Specular", 1)
+        mat.set_principled_shader_value("Specular IOR Level", 1)
         mat.set_principled_shader_value("Roughness", 0.3)
 
 # Find the object with name "Sphere"

--- a/examples/advanced/random_backgrounds/main.py
+++ b/examples/advanced/random_backgrounds/main.py
@@ -17,7 +17,7 @@ obj.set_cp("category_id", 1)
 
 # Randomly perturbate the material of the object
 mat = obj.get_materials()[0]
-mat.set_principled_shader_value("Specular", random.uniform(0, 1))
+mat.set_principled_shader_value("Specular IOR Level", random.uniform(0, 1))
 mat.set_principled_shader_value("Roughness", random.uniform(0, 1))
 mat.set_principled_shader_value("Base Color", np.random.uniform([0, 0, 0, 1], [1, 1, 1, 1]))
 mat.set_principled_shader_value("Metallic", random.uniform(0, 1))

--- a/examples/advanced/urdf_loading_and_manipulation/main.py
+++ b/examples/advanced/urdf_loading_and_manipulation/main.py
@@ -21,17 +21,17 @@ for link in robot.links:
             if 'mica' in link.get_name() and not 'drive' in link.get_name():
                 if 'distal' in link.get_name():
                     mat.set_principled_shader_value("Roughness", 0.3)
-                    mat.set_principled_shader_value("Specular", 0.8)
+                    mat.set_principled_shader_value("Specular IOR Level", 0.8)
                     mat.set_principled_shader_value("Base Color", [0.447, 0.3607, 0.3902, 1])
                     link.visuals[0].set_shading_mode('FLAT')
                 else:
                     mat.set_principled_shader_value("Roughness", 0.1)
                     mat.set_principled_shader_value("Metallic", 1.0)
-                    mat.set_principled_shader_value("Specular", 0.6)
+                    mat.set_principled_shader_value("Specular IOR Level", 0.6)
             else:
                 mat.set_principled_shader_value("Metallic", 0.3)
                 mat.set_principled_shader_value("Roughness", 0.4)
-                mat.set_principled_shader_value("Specular", 0.9)
+                mat.set_principled_shader_value("Specular IOR Level", 0.9)
 
 # rotate every joint for 0.1 radians relative to the previous position
 robot.set_rotation_euler_fk(link=None, rotation_euler=0.2, mode='relative', frame=0)

--- a/examples/datasets/bop_challenge/main_hb_random.py
+++ b/examples/datasets/bop_challenge/main_hb_random.py
@@ -75,7 +75,7 @@ for i in range(args.num_scenes):
             grey_col = np.random.uniform(0.1, 0.9)   
             mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
         mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-        mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+        mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
         obj.enable_rigidbody(True, mass=1.0, friction = 100.0, linear_damping = 0.99, angular_damping = 0.99)
         obj.hide(False)
     

--- a/examples/datasets/bop_challenge/main_icbin_random.py
+++ b/examples/datasets/bop_challenge/main_icbin_random.py
@@ -73,7 +73,7 @@ for i in range(args.num_scenes):
             grey_col = np.random.uniform(0.1, 0.9)   
             mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
         mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-        mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+        mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
         obj.enable_rigidbody(True, mass=1.0, friction = 100.0, linear_damping = 0.99, angular_damping = 0.99)
         obj.hide(False)
     

--- a/examples/datasets/bop_challenge/main_itodd_random.py
+++ b/examples/datasets/bop_challenge/main_itodd_random.py
@@ -72,7 +72,7 @@ for i in range(args.num_scenes):
             mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])      
         mat.set_principled_shader_value("Roughness", np.random.uniform(0, 0.5))
         if obj.get_cp("bop_dataset_name") == 'itodd':  
-            mat.set_principled_shader_value("Specular", np.random.uniform(0.3, 1.0))
+            mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.3, 1.0))
             mat.set_principled_shader_value("Metallic", np.random.uniform(0, 1.0))
         if obj.get_cp("bop_dataset_name") == 'tless':
             mat.set_principled_shader_value("Metallic", np.random.uniform(0, 0.5))

--- a/examples/datasets/bop_challenge/main_lm_upright.py
+++ b/examples/datasets/bop_challenge/main_lm_upright.py
@@ -73,7 +73,7 @@ for i in range(args.num_scenes):
             grey_col = np.random.uniform(0.1, 0.9)   
             mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
         mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-        mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+        mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
         obj.hide(False)
     
     # Sample two light sources

--- a/examples/datasets/bop_challenge/main_tless_random.py
+++ b/examples/datasets/bop_challenge/main_tless_random.py
@@ -78,7 +78,7 @@ for i in range(args.num_scenes):
         if obj.get_cp("bop_dataset_name") == 'itodd':  
             mat.set_principled_shader_value("Metallic", np.random.uniform(0.5, 1.0))
         if obj.get_cp("bop_dataset_name") == 'tless':
-            mat.set_principled_shader_value("Specular", np.random.uniform(0.3, 1.0))
+            mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.3, 1.0))
             mat.set_principled_shader_value("Metallic", np.random.uniform(0, 0.5))
         obj.enable_rigidbody(True, mass=1.0, friction = 100.0, linear_damping = 0.99, angular_damping = 0.99)
         obj.hide(False)

--- a/examples/datasets/bop_challenge/main_tudl_random.py
+++ b/examples/datasets/bop_challenge/main_tudl_random.py
@@ -75,7 +75,7 @@ for i in range(args.num_scenes):
             grey_col = np.random.uniform(0.1, 0.9)   
             mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
         mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-        mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+        mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
         obj.enable_rigidbody(True, mass=1.0, friction = 100.0, linear_damping = 0.99, angular_damping = 0.99)
         obj.hide(False)
     

--- a/examples/datasets/bop_challenge/main_ycbv_random.py
+++ b/examples/datasets/bop_challenge/main_ycbv_random.py
@@ -75,7 +75,7 @@ for i in range(args.num_scenes):
             grey_col = np.random.uniform(0.1, 0.9)   
             mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
         mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-        mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+        mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
         obj.enable_rigidbody(True, mass=1.0, friction = 100.0, linear_damping = 0.99, angular_damping = 0.99)
         obj.hide(False)
     

--- a/examples/datasets/bop_object_on_surface_sampling/README.md
+++ b/examples/datasets/bop_object_on_surface_sampling/README.md
@@ -93,7 +93,7 @@ for j, obj in enumerate(sampled_bop_objs + distractor_bop_objs):
         grey_col = np.random.uniform(0.3, 0.9)   
         mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
     mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-    mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+    mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
 ```
 
 * Sample grey colors for T-LESS object's materials using `np.random.uniform(0.3, 0.9)` function.

--- a/examples/datasets/bop_object_on_surface_sampling/main.py
+++ b/examples/datasets/bop_object_on_surface_sampling/main.py
@@ -41,7 +41,7 @@ for j, obj in enumerate(sampled_bop_objs + distractor_bop_objs):
         grey_col = np.random.uniform(0.3, 0.9)   
         mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
     mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-    mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+    mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
         
 # create room
 room_planes = [bproc.object.create_primitive('PLANE', scale=[2, 2, 1]),

--- a/examples/datasets/bop_object_physics_positioning/README.md
+++ b/examples/datasets/bop_object_physics_positioning/README.md
@@ -97,7 +97,7 @@ for j, obj in enumerate(sampled_bop_objs + distractor_bop_objs):
         grey_col = np.random.uniform(0.3, 0.9)   
         mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
     mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-    mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+    mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
 ```
 
 * Sample grey colors for T-LESS object's materials using `mat.set_principled_shader_value()` function.

--- a/examples/datasets/bop_object_physics_positioning/main.py
+++ b/examples/datasets/bop_object_physics_positioning/main.py
@@ -43,7 +43,7 @@ for j, obj in enumerate(sampled_bop_objs + distractor_bop_objs):
         grey_col = np.random.uniform(0.1, 0.9)   
         mat.set_principled_shader_value("Base Color", [grey_col, grey_col, grey_col, 1])        
     mat.set_principled_shader_value("Roughness", np.random.uniform(0, 1.0))
-    mat.set_principled_shader_value("Specular", np.random.uniform(0, 1.0))
+    mat.set_principled_shader_value("Specular IOR Level", np.random.uniform(0, 1.0))
         
 # create room
 room_planes = [bproc.object.create_primitive('PLANE', scale=[2, 2, 1]),

--- a/examples/datasets/shapenet/main.py
+++ b/examples/datasets/shapenet/main.py
@@ -9,7 +9,7 @@ args = parser.parse_args()
 bproc.init()
 
 # load the ShapeNet object into the scene
-shapenet_obj = bproc.loader.load_shapenet(args.shapenet_path, used_synset_id="02691156", used_source_id="10155655850468db78d106ce0a280f87")
+shapenet_obj = bproc.loader.load_shapenet(args.shapenet_path, used_synset_id="02691156", used_source_id="10155655850468db78d106ce0a280f87", validate_meshes=True)
 
 # define a light and set its location and energy level
 light = bproc.types.Light()

--- a/examples/datasets/suncg_with_improved_mat/README.md
+++ b/examples/datasets/suncg_with_improved_mat/README.md
@@ -56,7 +56,7 @@ all_wood_materials = bproc.filter.by_attr(all_materials, "name", "wood.*|laminat
 # now change the used values
 for material in all_wood_materials:
     material.set_principled_shader_value("Roughness", np.random.uniform(0.05, 0.5))
-    material.set_principled_shader_value("Specular", np.random.uniform(0.5, 1.0))
+    material.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.5, 1.0))
     material.set_displacement_from_principled_shader_value("Base Color", np.random.uniform(0.001, 0.15))
 
 all_stone_materials = bproc.filter.by_attr(all_materials, "name", "tile.*|brick.*|stone.*", regex=True)
@@ -64,14 +64,14 @@ all_stone_materials = bproc.filter.by_attr(all_materials, "name", "tile.*|brick.
 # now change the used values
 for material in all_stone_materials:
     material.set_principled_shader_value("Roughness", np.random.uniform(0.0, 0.2))
-    material.set_principled_shader_value("Specular", np.random.uniform(0.9, 1.0))
+    material.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.9, 1.0))
 
 all_floor_materials = bproc.filter.by_attr(all_materials, "name", "carpet.*|textile.*", regex=True)
 
 # now change the used values
 for material in all_floor_materials:
     material.set_principled_shader_value("Roughness", np.random.uniform(0.5, 1.0))
-    material.set_principled_shader_value("Specular", np.random.uniform(0.1, 0.3))
+    material.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.1, 0.3))
 
 ```
 
@@ -88,7 +88,7 @@ If you want to find out how your materials are named, click on the objects durin
 ```python
 for material in all_wood_materials:
     material.set_principled_shader_value("Roughness", np.random.uniform(0.05, 0.5))
-    material.set_principled_shader_value("Specular", np.random.uniform(0.5, 1.0))
+    material.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.5, 1.0))
     material.set_displacement_from_principled_shader_value("Base Color", np.random.uniform(0.001, 0.15))
 ```
 

--- a/examples/datasets/suncg_with_improved_mat/main.py
+++ b/examples/datasets/suncg_with_improved_mat/main.py
@@ -45,7 +45,7 @@ all_wood_materials = bproc.filter.by_attr(all_materials, "name", "wood.*|laminat
 # now change the used values
 for material in all_wood_materials:
     material.set_principled_shader_value("Roughness", np.random.uniform(0.05, 0.5))
-    material.set_principled_shader_value("Specular", np.random.uniform(0.5, 1.0))
+    material.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.5, 1.0))
     material.set_displacement_from_principled_shader_value("Base Color", np.random.uniform(0.001, 0.15))
 
 all_stone_materials = bproc.filter.by_attr(all_materials, "name", "tile.*|brick.*|stone.*", regex=True)
@@ -53,14 +53,14 @@ all_stone_materials = bproc.filter.by_attr(all_materials, "name", "tile.*|brick.
 # now change the used values
 for material in all_stone_materials:
     material.set_principled_shader_value("Roughness", np.random.uniform(0.0, 0.2))
-    material.set_principled_shader_value("Specular", np.random.uniform(0.9, 1.0))
+    material.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.9, 1.0))
 
 all_floor_materials = bproc.filter.by_attr(all_materials, "name", "carpet.*|textile.*", regex=True)
 
 # now change the used values
 for material in all_floor_materials:
     material.set_principled_shader_value("Roughness", np.random.uniform(0.5, 1.0))
-    material.set_principled_shader_value("Specular", np.random.uniform(0.1, 0.3))
+    material.set_principled_shader_value("Specular IOR Level", np.random.uniform(0.1, 0.3))
 
 # set the light bounces
 bproc.renderer.set_light_bounces(diffuse_bounces=200, glossy_bounces=200, max_bounces=200, transmission_bounces=200, transparent_max_bounces=200)


### PR DESCRIPTION
Transitions `blenderproc` to latest Blender LTS - 4.2.1. This enables to use new Blender features and advantages to its development also in the `blenderproc` environment. This enables:
- use new geometry nodes features
- load asset .blend files that were transitioned to 4.2.0 already
- take advantage of the improved cycles renderer (PrincipledBSDF, SoftFalloff)
- not be bound to older Blender versions when creating scenes that are then loaded into blenderproc

