### PR TITLE
doc(tests): minor text fixes.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,8 +3,8 @@
 The unit tests located in the `tests/` folder can be run via the following command:
 
 ```
-BP_CC_MATERIALS_PATH=<cc_matrials_path> BP_HAVEN_PATH=<haven_path>  python3 cli.py run tests/run_all.py
+BP_CC_MATERIALS_PATH=<cc_materials_path> BP_HAVEN_PATH=<haven_path>  python3 cli.py run tests/run_all.py
 ```
 
-where `<cc_matrials_path>` and `<haven_path>` are paths to the respective datasets.
-You can download them using blenderprocs [download command](docs/tutorials/loader.md).
+where `<cc_materials_path>` and `<haven_path>` are paths to the respective datasets.
+You can download them using blenderproc's [download command](/docs/tutorials/loader.md).


### PR DESCRIPTION
Fixes https://github.com/DLR-RM/BlenderProc/issues/1139.
Fix spelling: "cc_matrials_path" -> "cc_materials_path".
Add apostrophe "blenderprocs" -> "blenderproc's".
Make download command's URL absolute.