### PR TITLE
fix(loader): Preserves collection hierarchies when importing them from blend file

### DIFF
--- a/blenderproc/python/loader/BlendLoader.py
+++ b/blenderproc/python/loader/BlendLoader.py
@@ -24,7 +24,7 @@ def load_blend(path: str, obj_types: Optional[Union[List[str], str]] = None, nam
                         stored in a .blend file's folders, see Blender's documentation for bpy.types.ID
                         for more info) names.
     :param data_blocks: The data block or a list of data blocks which should be loaded from the given .blend file.
-                        Available options are: ['armatures', 'cameras', 'curves', 'hairs', 'hair_curves', 'images',
+                        Available options are: ['armatures', 'cameras', 'collections', 'curves', 'hairs', 'hair_curves', 'images',
                         'lights', 'materials', 'meshes', 'objects', 'textures']
     :param link: whether to link instead of append data blocks from .blend file. Linked objects can not be modified.
     :return: The list of loaded mesh objects.


### PR DESCRIPTION
When using
```
bproc.loader.load_blend("my.blend", data_blocks=["objects", "collections"])
```

the hierarchies between collections and objects should now be preserved. 

@johan-apes I think I found an easier way to fix the collection hierarchies. Could you please check whether this fix also works for you?

