### PR TITLE
add world.use_nodes=True to survive cleanup

### DIFF
--- a/blenderproc/python/loader/HavenEnvironmentLoader.py
+++ b/blenderproc/python/loader/HavenEnvironmentLoader.py
@@ -29,6 +29,7 @@ def set_world_background_hdr_img(path_to_hdr_file: str, strength: float = 1.0,
         raise FileNotFoundError(f"The given path does not exists: {path_to_hdr_file}")
 
     world = bpy.context.scene.world
+    world.use_nodes = True
     nodes = world.node_tree.nodes
     links = world.node_tree.links
 


### PR DESCRIPTION
This line is required to survive a `bproc.cleanup()`
Similar to https://github.com/DLR-RM/BlenderProc/blob/1ddf57026e3588bb770e97926c15baa5d9476ec7/blenderproc/python/renderer/RendererUtility.py#L829