### PR TITLE
feat(object): enhance MeshObjectUtility with new methods and type hints

### DIFF
--- a/blenderproc/python/types/MeshObjectUtility.py
+++ b/blenderproc/python/types/MeshObjectUtility.py
@@ -690,8 +690,7 @@ def create_primitive(shape: Literal["CUBE", "CYLINDER", "CONE", "PLANE", "SPHERE
                      **kwargs) -> MeshObject:
     """ Creates a new primitive mesh object.
 
-    :param shape: The name of the primitive to create. Available: ["CUBE", "CYLINDER", "CONE", "PLANE",
-                  "SPHERE", "MONKEY"]
+    :param shape: The name of the primitive to create.
     :return: The newly created MeshObject.
     """
     if shape == "CUBE":


### PR DESCRIPTION
- Introduce methods to get all modifiers and one specific modifier, similar to `get_materials`
- Update existing methods to return modifiers to facilitate subsequent changes to the modifier
- Add type hints for better clarity and type checking
- Improve comments
- Refactor `add_auto_smooth_modifier` to use new methods