### PR TITLE
feat(light): add utility functions for managing light objects

### DIFF
--- a/blenderproc/api/lighting/__init__.py
+++ b/blenderproc/api/lighting/__init__.py
@@ -1,3 +1,4 @@
 from blenderproc.python.lighting.SuncgLighting import light_suncg_scene
 from blenderproc.python.lighting.SurfaceLighting import light_surface
 from blenderproc.python.lighting.IntersectingSpotLight import add_intersecting_spot_lights_to_camera_poses
+from blenderproc.python.types.LightUtility import get_all_light_objects, convert_to_lights

--- a/blenderproc/python/types/LightUtility.py
+++ b/blenderproc/python/types/LightUtility.py
@@ -1,6 +1,6 @@
 """ This class allows the creation and management of lights in the scene. """
 
-from typing import Union, Optional
+from typing import Union, Optional, List
 
 import numpy as np
 import bpy
@@ -243,3 +243,28 @@ class Light(Entity):
         """
         with KeyFrame(frame):
             return self.blender_obj.data.type
+
+
+def get_all_blender_light_objects() -> List[bpy.types.Object]:
+    """ Retrieves all light objects in the current Blender scene.
+
+    :return: A list of all light objects in the current scene.
+    """
+    return [obj for obj in bpy.context.scene.objects if obj.type == 'LIGHT']
+
+
+def convert_to_lights(blender_objects: List[bpy.types.Object]) -> List[Light]:
+    """ Converts a list of Blender light objects to a list of BlenderProc light objects.
+
+    :param blender_objects: A list of Blender light objects.
+    :return: A list of BlenderProc light objects.
+    """
+    return [Light(blender_obj=obj) for obj in blender_objects]
+
+
+def get_all_light_objects() -> List[Light]:
+    """ Retrieves all light objects in the current Blender scene and converts them to BlenderProc light objects.
+
+    :return: A list of all light objects in the current scene.
+    """
+    return convert_to_lights(get_all_blender_light_objects())

--- a/blenderproc/python/types/LightUtility.py
+++ b/blenderproc/python/types/LightUtility.py
@@ -8,6 +8,7 @@ from mathutils import Color
 
 from blenderproc.python.types.EntityUtility import Entity
 from blenderproc.python.utility.Utility import Utility, KeyFrame
+from blenderproc.python.utility.BlenderUtility import get_all_blender_light_objects
 
 
 class Light(Entity):
@@ -243,14 +244,6 @@ class Light(Entity):
         """
         with KeyFrame(frame):
             return self.blender_obj.data.type
-
-
-def get_all_blender_light_objects() -> List[bpy.types.Object]:
-    """ Retrieves all light objects in the current Blender scene.
-
-    :return: A list of all light objects in the current scene.
-    """
-    return [obj for obj in bpy.context.scene.objects if obj.type == 'LIGHT']
 
 
 def convert_to_lights(blender_objects: List[bpy.types.Object]) -> List[Light]:

--- a/blenderproc/python/utility/BlenderUtility.py
+++ b/blenderproc/python/utility/BlenderUtility.py
@@ -117,6 +117,14 @@ def get_all_blender_mesh_objects() -> List[bpy.types.Object]:
     return [obj for obj in bpy.context.scene.objects if obj.type == 'MESH']
 
 
+def get_all_blender_light_objects() -> List[bpy.types.Object]:
+    """
+    Returns a list of all light objects in the scene
+    :return: a list of all light objects
+    """
+    return [obj for obj in bpy.context.scene.objects if obj.type == 'LIGHT']
+
+
 def get_all_materials() -> List[bpy.types.Material]:
     """
     Returns a list of all materials used and unused


### PR DESCRIPTION
Similar to the utility functions in `MeshObjectUtility` this PR does:
- Introduce `get_all_blender_light_objects` to retrieve all light objects in the scene
- Add `convert_to_lights` to convert Blender light objects to BlenderProc light objects
- Creates `get_all_light_objects` to combine the above functionalities for easier access to light objects