### PR TITLE
fix(loader): Fix TypeError on line 89

### DIFF
--- a/blenderproc/python/loader/BlendLoader.py
+++ b/blenderproc/python/loader/BlendLoader.py
@@ -86,7 +86,7 @@ def load_blend(path: str, obj_types: Optional[Union[List[str], str]] = None, nam
                                     max_keyframe = max(max_keyframe, keyframe.co[0])
 
                         # Set frame_end to the next free keyframe
-                        bpy.context.scene.frame_end = max_keyframe + 1
+                        bpy.context.scene.frame_end = int(max_keyframe + 1)
                 else:
                     # Remove object again if its type is not desired
                     bpy.data.objects.remove(obj, do_unlink=True)


### PR DESCRIPTION
fix(loader): Fix TypeError on line 89

This fix will allow BlenderProc to render scenes which rely on animations within the blend file to define frames.

closes #1206