### PR TITLE
fix: add delete of created ceiling if `create_ceiling=False`

### DIFF
--- a/blenderproc/python/constructor/RandomRoomConstructor.py
+++ b/blenderproc/python/constructor/RandomRoomConstructor.py
@@ -446,7 +446,12 @@ def _construct_random_room(used_floor_area: float, amount_of_extrusions: int, fa
                 if "Floor" == used_split_height[1]:
                     floor_obj = created_obj
                 elif "Ceiling" == used_split_height[1]:
-                    ceiling_obj = created_obj
+                    if create_ceiling:
+                        ceiling_obj = created_obj
+                    else:
+                        # delete the created ceiling if it should not be created
+                        created_obj.delete()
+                
     elif create_ceiling:
         # there is no ceiling -> create one
         wall_obj.edit_mode()


### PR DESCRIPTION
Adds additional check for the `create_ceiling` parameter in the rectangular room section of the extract_plane_from_room
In my opinion it is easier just deleting the plane instead of adjusting the for-loops, responsible for cutting of the planes.
 
closes #1212